### PR TITLE
Handle Clerk webhook user sync by userId

### DIFF
--- a/app/api/stripe/webhook/route.js
+++ b/app/api/stripe/webhook/route.js
@@ -86,7 +86,7 @@ export async function POST(request) {
       });
 
       // Clear cart
-      const user = await User.findById(userId);
+      const user = await User.findOne({ userId });
       if (user) {
         user.cartItems = [];
         await user.save();

--- a/config/inngest.js
+++ b/config/inngest.js
@@ -15,13 +15,16 @@ export const syncUserCreation = inngest.createFunction(
     const { id, first_name, last_name, email_addresses, image_url } =
       event.data;
     const userData = {
-      _id: id,
-      name: `${first_name}  ${last_name}`,
+      userId: id,
+      name: `${first_name} ${last_name}`,
       email: email_addresses[0].email_address,
       imageUrl: image_url,
     };
     await connectDB();
-    await User.create(userData);
+    await User.findOneAndUpdate({ userId: id }, userData, {
+      upsert: true,
+      new: true,
+    });
   }
 );
 
@@ -38,7 +41,11 @@ export const syncUserUpdation = inngest.createFunction(
       imageUrl: image_url,
     };
     await connectDB();
-    await User.findByIdAndUpdate(id, userData, userData);
+    await User.findOneAndUpdate(
+      { userId: id },
+      userData,
+      { new: true }
+    );
   }
 );
 
@@ -49,7 +56,7 @@ export const syncUserDeletion = inngest.createFunction(
   async ({ event }) => {
     const { id } = event.data;
     await connectDB();
-    await User.findByIdAndDelete(id);
+    await User.findOneAndDelete({ userId: id });
   }
 );
 


### PR DESCRIPTION
## Summary
- upsert Clerk user records by `userId` during Inngest creation and update flows
- delete users via `userId` to keep the database schema consistent
- align the Stripe webhook cart reset to look up users by `userId`

## Testing
- `npm run lint` *(fails: Cannot serialize key "parse" in parser: Function values are not supported.)*


------
https://chatgpt.com/codex/tasks/task_e_68c9d10de3148326a9a13e4c7da28455