### PR TITLE
Add client-side shop page with shared categories constant

### DIFF
--- a/app/all-products/page.jsx
+++ b/app/all-products/page.jsx
@@ -1,29 +1,8 @@
-"use client";
-import ProductCard from "@/components/ProductCard";
-import Navbar from "@/components/Navbar";
-import Footer from "@/components/Footer";
-import { useAppContext } from "@/context/AppContext";
+import { redirect } from "next/navigation";
 
-const AllProducts = () => {
-  const { products } = useAppContext();
-
-  return (
-    <>
-      <Navbar />
-      <div className="flex flex-col items-start px-6 md:px-16 lg:px-32">
-        <div className="flex flex-col items-end pt-12">
-          <p className="text-2xl font-medium">All products</p>
-          <div className="w-16 h-0.5 bg-primary rounded-full"></div>
-        </div>
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 flex-col items-center gap-6 mt-12 pb-14 w-full">
-          {products.map((product, index) => (
-            <ProductCard key={index} product={product} />
-          ))}
-        </div>
-      </div>
-      <Footer />
-    </>
-  );
+const AllProductsPage = () => {
+  redirect("/shop");
+  return null;
 };
 
-export default AllProducts;
+export default AllProductsPage;

--- a/app/cart/page.jsx
+++ b/app/cart/page.jsx
@@ -158,7 +158,7 @@ const Cart = () => {
 
           {/* Continue shopping */}
           <button
-            onClick={() => router.push("/all-products")}
+            onClick={() => router.push("/shop")}
             className="group flex items-center mt-6 gap-2 text-primary hover:text-tertiary transition-colors"
           >
             <Image

--- a/app/seller/page.jsx
+++ b/app/seller/page.jsx
@@ -5,14 +5,17 @@ import Image from "next/image";
 import { useAppContext } from "@/context/AppContext";
 import axios from "axios";
 import toast from "react-hot-toast";
+import { CATEGORIES } from "@/src/constants/categories";
 
 const AddProduct = () => {
   const { getToken } = useAppContext();
 
+  const defaultCategory = CATEGORIES[0] || "";
+
   const [files, setFiles] = useState([]);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [category, setCategory] = useState("Earphone");
+  const [category, setCategory] = useState(defaultCategory);
   const [price, setPrice] = useState("");
   const [offerPrice, setOfferPrice] = useState("");
 
@@ -41,7 +44,7 @@ const AddProduct = () => {
         setFiles([]);
         setName("");
         setDescription("");
-        setCategory("Earphone");
+        setCategory(defaultCategory);
         setPrice("");
         setOfferPrice("");
       } else {
@@ -126,15 +129,13 @@ const AddProduct = () => {
               id="category"
               className="outline-none md:py-2.5 py-2 px-3 rounded border border-gray-500/40"
               onChange={(e) => setCategory(e.target.value)}
-              defaultValue={category}
+              value={category}
             >
-              <option value="Earphone">Earphone</option>
-              <option value="Headphone">Headphone</option>
-              <option value="Watch">Watch</option>
-              <option value="Smartphone">Smartphone</option>
-              <option value="Laptop">Laptop</option>
-              <option value="Camera">Camera</option>
-              <option value="Accessories">Accessories</option>
+              {CATEGORIES.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
             </select>
           </div>
           <div className="flex flex-col gap-1 w-32">

--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -1,0 +1,67 @@
+import Footer from "@/components/Footer";
+import Navbar from "@/components/Navbar";
+import ShopClient from "@/components/ShopClient";
+import { headers } from "next/headers";
+
+const ensureAbsoluteUrl = (value) => {
+  if (!value) return undefined;
+  if (value.startsWith("http://") || value.startsWith("https://")) {
+    return value.replace(/\/$/, "");
+  }
+
+  const protocol = process.env.NODE_ENV === "development" ? "http" : "https";
+  return `${protocol}://${value.replace(/\/$/, "")}`;
+};
+
+const resolveBaseUrl = () => {
+  const envUrl =
+    ensureAbsoluteUrl(process.env.NEXT_PUBLIC_SITE_URL) ||
+    ensureAbsoluteUrl(process.env.NEXT_PUBLIC_BASE_URL) ||
+    ensureAbsoluteUrl(process.env.NEXTAUTH_URL) ||
+    ensureAbsoluteUrl(process.env.SITE_URL) ||
+    ensureAbsoluteUrl(process.env.VERCEL_URL);
+
+  if (envUrl) return envUrl;
+
+  const headerList = headers();
+  const host = headerList.get("host");
+  if (!host) return undefined;
+
+  const protocol = host.includes("localhost") || host.startsWith("127.") ? "http" : "https";
+  return `${protocol}://${host}`;
+};
+
+const fetchProducts = async () => {
+  try {
+    const baseUrl = resolveBaseUrl();
+    if (!baseUrl) return [];
+
+    const response = await fetch(`${baseUrl}/api/product/list`, {
+      cache: "no-store",
+    });
+
+    if (!response.ok) return [];
+
+    const data = await response.json();
+    if (!data?.success || !Array.isArray(data.products)) return [];
+
+    return data.products;
+  } catch (error) {
+    console.error("Failed to load products for shop page", error);
+    return [];
+  }
+};
+
+const ShopPage = async () => {
+  const products = await fetchProducts();
+
+  return (
+    <>
+      <Navbar />
+      <ShopClient products={products} />
+      <Footer />
+    </>
+  );
+};
+
+export default ShopPage;

--- a/components/HeroBanner.jsx
+++ b/components/HeroBanner.jsx
@@ -20,7 +20,7 @@ const HeroBanner = () => {
           Explore the latest posters and premium materials.
         </p>
         <Link
-          href="/all-products"
+          href="/shop"
           className=" inline-block mt-8 bg-tertiary hover:bg-secondary text-white px-10 py-4 rounded-full transition font-[700]"
         >
           Shop Now

--- a/components/HomeProducts.jsx
+++ b/components/HomeProducts.jsx
@@ -18,7 +18,7 @@ const HomeProducts = () => {
       </div>
       <button
         onClick={() => {
-          router.push("/all-products");
+          router.push("/shop");
         }}
         className="px-10 py-4 rounded-full bg-white border-2 border-blackhex text-blackhex hover:bg-blackhex hover:text-white hover:border-white transition font-[700]"
       >

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -29,7 +29,7 @@ const Navbar = () => {
           {/* Animated underline */}
         </Link>
         <Link
-          href="/all-products"
+          href="/shop"
           className="relative hover:text-secondary transition-colors duration-300 group"
         >
           Shop
@@ -98,7 +98,7 @@ const Navbar = () => {
                 <UserButton.Action
                   label="Products"
                   labelIcon={<BoxIcon />}
-                  onClick={() => router.push("/all-products")}
+                  onClick={() => router.push("/shop")}
                 />
               </UserButton.MenuItems>
               <UserButton.MenuItems>
@@ -157,7 +157,7 @@ const Navbar = () => {
                 <UserButton.Action
                   label="Products"
                   labelIcon={<BoxIcon />}
-                  onClick={() => router.push("/all-products")}
+                  onClick={() => router.push("/shop")}
                 />
               </UserButton.MenuItems>
 

--- a/components/ShopClient.jsx
+++ b/components/ShopClient.jsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import ProductCard from "@/components/ProductCard";
+import { CATEGORIES } from "@/src/constants/categories";
+
+const SORT_OPTIONS = [
+  { label: "Featured", value: "featured" },
+  { label: "Price: Low to High", value: "price-asc" },
+  { label: "Price: High to Low", value: "price-desc" },
+];
+
+const getComparablePrice = (product) => {
+  const offer = Number(product?.offerPrice ?? 0);
+  const price = Number(product?.price ?? 0);
+  if (!Number.isNaN(offer) && offer > 0) return offer;
+  if (!Number.isNaN(price) && price > 0) return price;
+  return 0;
+};
+
+const normalizeProducts = (products) =>
+  Array.isArray(products)
+    ? products.filter((product) =>
+        product && typeof product === "object" && product.image?.length
+      )
+    : [];
+
+const ShopClient = ({ products }) => {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [activeCategory, setActiveCategory] = useState("all");
+  const [sortOrder, setSortOrder] = useState(SORT_OPTIONS[0].value);
+
+  const normalizedProducts = useMemo(
+    () => normalizeProducts(products),
+    [products]
+  );
+
+  const categoryCounts = useMemo(() => {
+    const counts = new Map();
+    for (const category of CATEGORIES) {
+      counts.set(category, 0);
+    }
+
+    for (const product of normalizedProducts) {
+      if (product?.category && counts.has(product.category)) {
+        counts.set(product.category, (counts.get(product.category) ?? 0) + 1);
+      }
+    }
+
+    return counts;
+  }, [normalizedProducts]);
+
+  const filteredProducts = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    const matchesSearch = (product) => {
+      if (!term) return true;
+      return (
+        product.name?.toLowerCase().includes(term) ||
+        product.description?.toLowerCase().includes(term)
+      );
+    };
+
+    const matchesCategory = (product) => {
+      if (activeCategory === "all") return true;
+      return product.category === activeCategory;
+    };
+
+    const sortedProducts = normalizedProducts
+      .filter((product) => matchesSearch(product) && matchesCategory(product))
+      .map((product) => ({ ...product }));
+
+    if (sortOrder === "price-asc" || sortOrder === "price-desc") {
+      const direction = sortOrder === "price-asc" ? 1 : -1;
+      sortedProducts.sort((a, b) => {
+        const priceA = getComparablePrice(a);
+        const priceB = getComparablePrice(b);
+        return (priceA - priceB) * direction;
+      });
+    }
+
+    return sortedProducts;
+  }, [activeCategory, normalizedProducts, searchTerm, sortOrder]);
+
+  return (
+    <main className="px-6 md:px-10 lg:px-16 xl:px-24 py-12">
+      <div className="flex flex-col gap-10 lg:flex-row">
+        <aside className="lg:w-64 flex-shrink-0">
+          <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-gray-900">Categories</h2>
+              <button
+                type="button"
+                onClick={() => setActiveCategory("all")}
+                className="text-sm font-medium text-primary hover:text-orange-700"
+              >
+                Reset
+              </button>
+            </div>
+            <ul className="mt-6 space-y-2 text-sm text-gray-600">
+              <li>
+                <button
+                  type="button"
+                  onClick={() => setActiveCategory("all")}
+                  className={`flex w-full items-center justify-between rounded-xl px-4 py-2 transition ${
+                    activeCategory === "all"
+                      ? "bg-orange-50 text-orange-600"
+                      : "hover:bg-gray-50"
+                  }`}
+                >
+                  <span>All products</span>
+                  <span className="text-xs font-medium text-gray-500">
+                    {normalizedProducts.length}
+                  </span>
+                </button>
+              </li>
+              {CATEGORIES.map((category) => (
+                <li key={category}>
+                  <button
+                    type="button"
+                    onClick={() => setActiveCategory(category)}
+                    className={`flex w-full items-center justify-between rounded-xl px-4 py-2 transition ${
+                      activeCategory === category
+                        ? "bg-orange-50 text-orange-600"
+                        : "hover:bg-gray-50"
+                    }`}
+                  >
+                    <span>{category}</span>
+                    <span className="text-xs font-medium text-gray-500">
+                      {categoryCounts.get(category) ?? 0}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </aside>
+
+        <section className="flex-1 space-y-8">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h1 className="text-3xl font-semibold text-gray-900">Shop</h1>
+              <p className="mt-1 text-sm text-gray-500">
+                Showing {filteredProducts.length} of {normalizedProducts.length} products
+              </p>
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <label className="flex items-center gap-3 rounded-full border border-gray-200 bg-white px-4 py-2 shadow-sm">
+                <span className="text-sm text-gray-500">Search</span>
+                <input
+                  type="text"
+                  value={searchTerm}
+                  onChange={(event) => setSearchTerm(event.target.value)}
+                  placeholder="Products, categories..."
+                  className="w-40 bg-transparent text-sm outline-none placeholder:text-gray-400"
+                />
+              </label>
+              <label className="flex items-center gap-3 rounded-full border border-gray-200 bg-white px-4 py-2 shadow-sm">
+                <span className="text-sm text-gray-500">Sort by</span>
+                <select
+                  value={sortOrder}
+                  onChange={(event) => setSortOrder(event.target.value)}
+                  className="bg-transparent text-sm font-medium outline-none"
+                >
+                  {SORT_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </div>
+
+          {filteredProducts.length > 0 ? (
+            <div className="grid grid-cols-2 gap-6 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+              {filteredProducts.map((product) => (
+                <ProductCard key={product?._id ?? product?.productId} product={product} />
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-3xl border border-dashed border-gray-300 bg-white/80 p-12 text-center text-gray-500">
+              <h2 className="text-xl font-semibold text-gray-800">
+                No products found
+              </h2>
+              <p className="mt-2 text-sm">
+                Try clearing your filters or searching for a different item.
+              </p>
+              <button
+                type="button"
+                onClick={() => {
+                  setSearchTerm("");
+                  setActiveCategory("all");
+                  setSortOrder(SORT_OPTIONS[0].value);
+                }}
+                className="mt-6 inline-flex items-center rounded-full bg-orange-500 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-orange-600"
+              >
+                Reset filters
+              </button>
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+};
+
+export default ShopClient;

--- a/components/product/ProductPage.jsx
+++ b/components/product/ProductPage.jsx
@@ -15,7 +15,7 @@ export default function ProductPage({ product }) {
     <div className="w-full">
       {/* Breadcrumb spans the page, not just the left column */}
       <nav className="text-sm text-gray-600 mb-4">
-        <Link href="/all-products" className="hover:text-black">
+        <Link href="/shop" className="hover:text-black">
           Browse All
         </Link>
         <span className="mx-2">›</span>

--- a/models/Product.js
+++ b/models/Product.js
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import { CATEGORIES } from "@/src/constants/categories";
 
 const productSchema = new mongoose.Schema({
   userId: { type: String, required: true, ref: "User" },
@@ -8,7 +9,7 @@ const productSchema = new mongoose.Schema({
   offerPrice: { type: Number, default: null },
   digitalPrice: { type: Number, default: 0 },
   image: { type: [String], required: true },
-  category: { type: String, required: true },
+  category: { type: String, required: true, enum: CATEGORIES },
   PrintfulEnabled: { type: Boolean, default: false },
   orientation: {
     type: String,

--- a/src/constants/categories.js
+++ b/src/constants/categories.js
@@ -1,0 +1,9 @@
+export const CATEGORIES = Object.freeze([
+  "Earphone",
+  "Headphone",
+  "Watch",
+  "Smartphone",
+  "Laptop",
+  "Camera",
+  "Accessories",
+]);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+const config = {
   content: [
     "./app/**/*.{js,jsx}",
     "./components/**/*.{js,jsx}",
@@ -39,3 +39,5 @@ export default {
   },
   plugins: [],
 };
+
+export default config;


### PR DESCRIPTION
## Summary
- add a shared CATEGORIES constant and reuse it in the seller form and product schema
- create a client-driven ShopClient view and wire it up to the new /shop route with server-side fetching
- redirect legacy /all-products traffic and update navigation links to point at the shop experience

## Testing
- npm run lint *(fails: Cannot serialize key "parse" in parser: Function values are not supported.)*
- npx eslint .


------
https://chatgpt.com/codex/tasks/task_e_68d1ecef2cb88326a888bdedb965d349