### PR TITLE
Ensure seller orders populate product details

### DIFF
--- a/app/api/order/seller-orders/route.js
+++ b/app/api/order/seller-orders/route.js
@@ -19,7 +19,9 @@ export async function GET(request) {
 
     Address.length;
 
-    const orders = await Order.find({}).populate("address items.product");
+    const orders = await Order.find({})
+      .populate("address")
+      .populate({ path: "items.product", model: "product" });
 
     return NextResponse.json({ success: true, orders });
   } catch (error) {

--- a/app/seller/orders/page.jsx
+++ b/app/seller/orders/page.jsx
@@ -63,9 +63,10 @@ const Orders = () => {
                   <p className="flex flex-col gap-3">
                     <span className="font-medium">
                       {order.items
-                        .map(
-                          (item) => item.product.name + ` x ${item.quantity}`
-                        )
+                        .map((item) => {
+                          const productName = item.product?.name || "Unknown Product";
+                          return `${productName} x ${item.quantity}`;
+                        })
                         .join(", ")}
                     </span>
                     <span>Items : {order.items.length}</span>


### PR DESCRIPTION
## Summary
- ensure seller order API populates both address and product references on fetched orders
- add a fallback label for items without populated product data in the seller orders UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe2e9374c8326bbb6d0e774c13786