### PR TITLE
Load shop products directly from MongoDB

### DIFF
--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -2,33 +2,39 @@ import React from "react";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import ShopClient from "@/components/ShopClient";
+import connectDB from "@/config/db";
+import Product from "@/models/Product";
 
-// ✅ force dynamic because we want live data
 export const dynamic = "force-dynamic";
 
-const fetchProducts = async () => {
+const getProducts = async () => {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_BASE_URL}/api/product/list`,
-      {
-        cache: "no-store",
-      }
-    );
+    await connectDB();
 
-    if (!response.ok) {
-      throw new Error("Failed to fetch products");
-    }
+    const products = await Product.find({})
+      .sort({ date: -1 })
+      .lean();
 
-    const data = await response.json();
-    return data?.success ? data.products : [];
-  } catch (err) {
-    console.error("fetchProducts error:", err);
+    return products.map((product) => ({
+      ...product,
+      _id: product._id?.toString?.() ?? "",
+      userId:
+        typeof product.userId === "object" && product.userId !== null
+          ? product.userId.toString()
+          : product.userId ?? "",
+      date:
+        product.date instanceof Date
+          ? product.date.toISOString()
+          : product.date ?? null,
+    }));
+  } catch (error) {
+    console.error("getProducts error:", error);
     return [];
   }
 };
 
 const ShopPage = async () => {
-  const products = await fetchProducts();
+  const products = await getProducts();
 
   return (
     <>


### PR DESCRIPTION
## Summary
- fetch shop page products directly via the Product model instead of the product list API
- ensure MongoDB connection is established in the server component before querying
- normalize product documents for serialization before passing them to ShopClient

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df16e797488326b4fe64fcba8df5ad