### PR TITLE
feat: add wishlist support

### DIFF
--- a/app/api/wishlist/add/route.js
+++ b/app/api/wishlist/add/route.js
@@ -1,0 +1,68 @@
+import connectDB from "@/config/db";
+import Wishlist from "@/models/Wishlist";
+import User from "@/models/User";
+import { getAuth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+export async function POST(request) {
+  try {
+    const { userId } = getAuth(request);
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, message: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const { productId } = await request.json();
+    if (!productId) {
+      return NextResponse.json(
+        { success: false, message: "Product ID is required" },
+        { status: 400 }
+      );
+    }
+
+    await connectDB();
+
+    const user = await User.findOne({ userId });
+    if (!user) {
+      return NextResponse.json(
+        { success: false, message: "User not found" },
+        { status: 404 }
+      );
+    }
+
+    let wishlist = await Wishlist.findOne({ user: user._id });
+
+    if (!wishlist) {
+      wishlist = await Wishlist.create({ user: user._id, items: [] });
+    }
+
+    const alreadyExists = wishlist.items.some(
+      (item) => item.product?.toString() === productId
+    );
+
+    if (!alreadyExists) {
+      wishlist.items.push({ product: productId });
+      await wishlist.save();
+    }
+
+    await wishlist.populate({
+      path: "items.product",
+      select: "title imageUrl price",
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: alreadyExists
+        ? "Product already in wishlist"
+        : "Product added to wishlist",
+      wishlist,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/wishlist/get/route.js
+++ b/app/api/wishlist/get/route.js
@@ -1,0 +1,41 @@
+import connectDB from "@/config/db";
+import Wishlist from "@/models/Wishlist";
+import User from "@/models/User";
+import { getAuth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+export async function GET(request) {
+  try {
+    const { userId } = getAuth(request);
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, message: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    await connectDB();
+
+    const user = await User.findOne({ userId });
+    if (!user) {
+      return NextResponse.json(
+        { success: false, message: "User not found" },
+        { status: 404 }
+      );
+    }
+
+    const wishlist = await Wishlist.findOne({ user: user._id })
+      .populate({ path: "items.product", select: "title imageUrl price" })
+      .lean();
+
+    return NextResponse.json({
+      success: true,
+      wishlist: wishlist || { user: user._id, items: [] },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/wishlist/remove/route.js
+++ b/app/api/wishlist/remove/route.js
@@ -1,0 +1,72 @@
+import connectDB from "@/config/db";
+import Wishlist from "@/models/Wishlist";
+import User from "@/models/User";
+import { getAuth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+export async function POST(request) {
+  try {
+    const { userId } = getAuth(request);
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, message: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const { productId } = await request.json();
+    if (!productId) {
+      return NextResponse.json(
+        { success: false, message: "Product ID is required" },
+        { status: 400 }
+      );
+    }
+
+    await connectDB();
+
+    const user = await User.findOne({ userId });
+    if (!user) {
+      return NextResponse.json(
+        { success: false, message: "User not found" },
+        { status: 404 }
+      );
+    }
+
+    const wishlist = await Wishlist.findOne({ user: user._id });
+    if (!wishlist) {
+      return NextResponse.json({
+        success: true,
+        message: "Wishlist is empty",
+        wishlist: { user: user._id, items: [] },
+      });
+    }
+
+    const initialLength = wishlist.items.length;
+    wishlist.items = wishlist.items.filter(
+      (item) => item.product?.toString() !== productId
+    );
+
+    if (wishlist.items.length !== initialLength) {
+      await wishlist.save();
+    }
+
+    await wishlist.populate({
+      path: "items.product",
+      select: "title imageUrl price",
+    });
+
+    return NextResponse.json({
+      success: true,
+      message:
+        wishlist.items.length === initialLength
+          ? "Product not found in wishlist"
+          : "Product removed from wishlist",
+      wishlist,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,3 +25,35 @@ body {
 ::-webkit-scrollbar {
   display: none;
 }
+
+@keyframes wishlist-pop {
+  0% {
+    transform: scale(1);
+  }
+  55% {
+    transform: scale(1.18);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes wishlist-unpop {
+  0% {
+    transform: scale(1);
+  }
+  55% {
+    transform: scale(0.88);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.animate-wishlist-pop {
+  animation: wishlist-pop 0.25s ease-in-out;
+}
+
+.animate-wishlist-unpop {
+  animation: wishlist-unpop 0.25s ease-in-out;
+}

--- a/app/wishlist/page.jsx
+++ b/app/wishlist/page.jsx
@@ -1,0 +1,158 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import Navbar from "@/components/Navbar";
+import { useAppContext } from "@/context/AppContext";
+import { Heart } from "lucide-react";
+
+const resolveProductId = (product) => {
+  if (!product) return "";
+  if (typeof product?._id === "object" && product?._id !== null) {
+    return product._id.toString();
+  }
+  return product?._id ?? product?.productId ?? product?.id ?? "";
+};
+
+const resolvePrice = (product) => {
+  const value =
+    product?.pricing?.defaultPhysicalFinalPrice ??
+    product?.pricing?.defaultDigitalFinalPrice ??
+    product?.pricing?.defaultFinalPrice ??
+    product?.offerPrice ??
+    product?.finalPrice ??
+    product?.price ??
+    0;
+
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) return 0;
+  return Math.max(parsed, 0);
+};
+
+const resolveImage = (product) => {
+  if (!product) return "";
+  if (Array.isArray(product.image) && product.image.length > 0) {
+    return product.image[0];
+  }
+  if (Array.isArray(product.images) && product.images.length > 0) {
+    return product.images[0];
+  }
+  return product.imageUrl || product.thumbnail || "";
+};
+
+const WishlistPage = () => {
+  const { wishlist, currency, removeFromWishlist, router } = useAppContext();
+
+  const wishlistProducts = (wishlist || [])
+    .map((entry) => entry?.product ?? entry)
+    .filter((product) => resolveProductId(product));
+
+  return (
+    <>
+      <Navbar />
+      <main className="px-6 pb-20 pt-16 md:px-16 lg:px-32">
+        <section className="mx-auto flex w-full max-w-6xl flex-col gap-12">
+          <header className="flex flex-col gap-2 border-b border-gray-200 pb-6">
+            <h1 className="text-3xl font-semibold text-blackhex md:text-4xl">
+              Your <span className="text-primary">Wishlist</span>
+            </h1>
+            <p className="text-sm text-gray-500 md:text-base">
+              Save posters you love and revisit them anytime. Move your
+              favourites to the cart when you&apos;re ready to make them yours.
+            </p>
+          </header>
+
+          {wishlistProducts.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-6 rounded-3xl bg-white py-16 text-center shadow-md">
+              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-pink-100 text-pink-500">
+                <Heart className="h-8 w-8" fill="currentColor" strokeWidth={1.6} />
+              </div>
+              <div className="space-y-2">
+                <h2 className="text-2xl font-semibold text-blackhex">
+                  Your wishlist is empty 💔
+                </h2>
+                <p className="text-gray-500">
+                  Browse our collection and tap the heart icon to keep track of
+                  your must-have posters.
+                </p>
+              </div>
+              <Link
+                href="/shop"
+                className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white transition-transform duration-200 hover:scale-105 active:scale-95"
+              >
+                Discover posters
+              </Link>
+            </div>
+          ) : (
+            <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+              {wishlistProducts.map((product) => {
+                const id = resolveProductId(product);
+                const price = resolvePrice(product);
+                const image = resolveImage(product);
+
+                return (
+                  <article
+                    key={id}
+                    className="group flex flex-col overflow-hidden rounded-3xl bg-white shadow-md transition hover:-translate-y-1 hover:shadow-xl"
+                  >
+                    <div className="relative aspect-[4/5] w-full overflow-hidden bg-gray-50">
+                      {image ? (
+                        <Image
+                          src={image}
+                          alt={product?.name || product?.title || "Wishlist item"}
+                          fill
+                          className="object-cover transition-transform duration-300 group-hover:scale-105"
+                          sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                        />
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center bg-gray-100 text-sm text-gray-400">
+                          Image coming soon
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="flex flex-1 flex-col gap-4 p-6">
+                      <div className="flex flex-col gap-2">
+                        <h3 className="text-lg font-semibold text-blackhex">
+                          {product?.name || product?.title || "Untitled Poster"}
+                        </h3>
+                        <p className="text-sm text-gray-500 line-clamp-2">
+                          {product?.description ||
+                            "Open the product details to explore formats, dimensions, and more."}
+                        </p>
+                      </div>
+
+                      <p className="text-base font-semibold text-primary">
+                        {(currency || "$")}
+                        {price.toFixed(2)}
+                      </p>
+
+                      <div className="mt-auto flex flex-wrap gap-3">
+                        <button
+                          type="button"
+                          onClick={() => router.push(`/product/${id}`)}
+                          className="flex-1 rounded-full border border-primary px-4 py-2 text-sm font-medium text-primary transition-transform duration-200 hover:scale-[1.02] hover:bg-primary/5 active:scale-95"
+                        >
+                          View details
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => removeFromWishlist(id)}
+                          className="flex-1 rounded-full bg-gradient-to-r from-pink-500 to-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition-transform duration-200 hover:scale-[1.02] active:scale-95"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      </main>
+    </>
+  );
+};
+
+export default WishlistPage;

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -6,11 +6,13 @@ import { useAppContext } from "@/context/AppContext";
 import Image from "next/image";
 import { useClerk, UserButton } from "@clerk/nextjs";
 import TopBanner from "@/components/TopBanner";
+import { Heart } from "lucide-react";
 
 const Navbar = () => {
-  const { isAdmin, router, user, getCartCount } = useAppContext();
+  const { isAdmin, router, user, getCartCount, wishlist } = useAppContext();
   const { openSignIn } = useClerk();
   const cartCount = getCartCount();
+  const wishlistCount = wishlist?.length ?? 0;
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const closeMenu = () => setIsMenuOpen(false);
@@ -88,6 +90,27 @@ const Navbar = () => {
               className="ml-2 bg-transparent text-sm outline-none w-full"
             />
           </form>
+          {/* wishlist */}
+          <button
+            type="button"
+            onClick={() => router.push("/wishlist")}
+            className="relative flex items-center justify-center text-gray-600 transition-transform duration-200 hover:scale-110 hover:text-secondary active:scale-95"
+            aria-label="View wishlist"
+          >
+            <Heart
+              className={`h-5 w-5 ${
+                wishlistCount > 0 ? "text-pink-500" : "text-gray-600"
+              }`}
+              fill={wishlistCount > 0 ? "currentColor" : "none"}
+              strokeWidth={1.8}
+            />
+            {wishlistCount > 0 && (
+              <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-pink-500 text-[10px] font-semibold leading-none text-white">
+                {wishlistCount > 99 ? "99+" : wishlistCount}
+              </span>
+            )}
+          </button>
+
           {/* cart */}
           <Link href="/cart" className="relative">
             <Image
@@ -154,6 +177,26 @@ const Navbar = () => {
         </ul>
 
         <div className="flex items-center lg:hidden gap-3">
+          <button
+            type="button"
+            onClick={() => router.push("/wishlist")}
+            className="relative flex items-center justify-center text-gray-600 transition-transform duration-200 hover:scale-110 hover:text-secondary active:scale-95"
+            aria-label="View wishlist"
+          >
+            <Heart
+              className={`h-6 w-6 ${
+                wishlistCount > 0 ? "text-pink-500" : "text-gray-600"
+              }`}
+              fill={wishlistCount > 0 ? "currentColor" : "none"}
+              strokeWidth={1.8}
+            />
+            {wishlistCount > 0 && (
+              <span className="absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-pink-500 text-[10px] font-semibold leading-none text-white">
+                {wishlistCount > 99 ? "99+" : wishlistCount}
+              </span>
+            )}
+          </button>
+
           <Link href="/cart" className="relative">
             <Image
               className="w-6 h-6"

--- a/components/ProductCard.jsx
+++ b/components/ProductCard.jsx
@@ -1,63 +1,159 @@
-import React from "react";
-import { assets } from "@/assets/assets";
+"use client";
+
+import React, { useMemo, useState } from "react";
 import Image from "next/image";
+import { Heart } from "lucide-react";
 import { useAppContext } from "@/context/AppContext";
 
 const ProductCard = ({ product }) => {
-  const { currency, router } = useAppContext();
+  const {
+    currency,
+    router,
+    wishlist,
+    addToWishlist,
+    removeFromWishlist,
+  } = useAppContext();
+  const [wishlistAnimation, setWishlistAnimation] = useState("");
+
+  const productId = useMemo(() => {
+    if (!product) return "";
+    if (typeof product?._id === "object" && product?._id !== null) {
+      return product._id.toString();
+    }
+    return (
+      product?._id ?? product?.productId ?? product?.id ?? product?.slug ?? ""
+    );
+  }, [product]);
+
+  const previewImage = useMemo(() => {
+    if (!product) return "";
+    if (Array.isArray(product.image) && product.image.length > 0) {
+      return product.image[0];
+    }
+    if (Array.isArray(product.images) && product.images.length > 0) {
+      return product.images[0];
+    }
+    return product.imageUrl || product.thumbnail || "";
+  }, [product]);
+
+  const displayPrice = useMemo(() => {
+    const rawPrice =
+      product?.pricing?.defaultPhysicalFinalPrice ??
+      product?.pricing?.defaultDigitalFinalPrice ??
+      product?.pricing?.defaultFinalPrice ??
+      product?.offerPrice ??
+      product?.finalPrice ??
+      product?.price ??
+      0;
+    const numericPrice = Number(rawPrice);
+    if (Number.isNaN(numericPrice)) return 0;
+    return Math.max(numericPrice, 0);
+  }, [product]);
+
+  const isWishlisted = useMemo(() => {
+    if (!productId) return false;
+
+    return wishlist.some((entry) => {
+      const entryProduct = entry?.product ?? entry;
+
+      if (!entryProduct) return false;
+
+      if (
+        typeof entryProduct?._id === "object" &&
+        entryProduct?._id !== null &&
+        entryProduct._id.toString() === productId
+      ) {
+        return true;
+      }
+
+      const directId =
+        entryProduct?._id ?? entryProduct?.productId ?? entryProduct?.id;
+
+      return directId === productId;
+    });
+  }, [productId, wishlist]);
+
+  const handleCardClick = () => {
+    if (!productId) return;
+    router.push(`/product/${productId}`);
+    scrollTo(0, 0);
+  };
+
+  const toggleWishlist = (event) => {
+    event?.preventDefault();
+    event?.stopPropagation();
+
+    if (!productId) return;
+
+    const animationClass = isWishlisted
+      ? "animate-wishlist-unpop"
+      : "animate-wishlist-pop";
+    setWishlistAnimation(animationClass);
+
+    if (isWishlisted) {
+      removeFromWishlist(productId);
+    } else {
+      addToWishlist(productId);
+    }
+
+    setTimeout(() => {
+      setWishlistAnimation("");
+    }, 220);
+  };
 
   return (
     <div
-      onClick={() => {
-        router.push("/product/" + product._id);
-        scrollTo(0, 0);
-      }}
-      className="flex flex-col items-start max-w-[250px] w-full cursor-pointer"
+      onClick={handleCardClick}
+      className="flex w-full max-w-[250px] cursor-pointer flex-col items-start"
     >
-      <div className="cursor-pointer group relative w-full h-80 flex items-center justify-center shadow-poster">
-        <Image
-          src={product.image[0]}
-          alt={product.name}
-          className="group-hover:scale-105 transition w-full h-full object-cover md:w-full md:h-full"
-          width={800}
-          height={800}
-        />
-        <button className="absolute top-3 right-3 bg-white p-2 rounded-full shadow-md">
-          <Image className="h-3 w-3" src={assets.heart_icon} alt="heart_icon" />
+      <div className="group relative flex h-80 w-full items-center justify-center overflow-hidden rounded-2xl bg-gray-50 shadow-poster transition">
+        {previewImage ? (
+          <Image
+            src={previewImage}
+            alt={product?.name || product?.title || "Poster"}
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+            width={800}
+            height={800}
+            sizes="(max-width: 768px) 50vw, 25vw"
+            priority={false}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gray-100 text-gray-400">
+            No image
+          </div>
+        )}
+
+        <button
+          type="button"
+          aria-label={
+            isWishlisted ? "Remove from wishlist" : "Add to wishlist"
+          }
+          aria-pressed={isWishlisted}
+          onClick={toggleWishlist}
+          className="absolute top-3 right-3 flex cursor-pointer items-center justify-center rounded-full bg-white/90 p-2 text-gray-600 shadow-md transition-transform duration-200 hover:scale-110 hover:text-secondary active:scale-95"
+        >
+          <Heart
+            className={`h-5 w-5 transition-colors duration-200 ${
+              isWishlisted ? "text-pink-500" : "text-gray-600"
+            } ${wishlistAnimation}`}
+            fill={isWishlisted ? "currentColor" : "none"}
+            strokeWidth={1.8}
+          />
         </button>
       </div>
 
-      {/* <p className="md:text-base font-medium pt-2 w-full truncate">
-        {product.name}
-      </p> */}
-      {/* <p className="w-full text-xs text-gray-500/70 max-sm:hidden truncate">
-        {product.description}
-      </p> */}
-      {/* <div className="flex items-center gap-2"> */}
-      {/* <p className="text-xs">{4.5}</p> */}
-      {/* <div className="flex items-center gap-0.5">
-          {Array.from({ length: 5 }).map((_, index) => (
-            <Image
-              key={index}
-              className="h-3 w-3"
-              src={
-                index < Math.floor(4) ? assets.star_icon : assets.star_dull_icon
-              }
-              alt="star_icon"
-            />
-          ))}
-        </div> */}
-      {/* </div> */}
-
-      {/* <div className="flex items-end justify-between w-full mt-1">
-        <p className="text-base font-medium">
-          {currency}
-          {product.offerPrice}
+      <div className="mt-4 flex w-full flex-col gap-2 text-left">
+        <p className="truncate text-base font-semibold text-blackhex">
+          {product?.name || product?.title || "Untitled Poster"}
         </p>
-        <button className=" max-sm:hidden px-4 py-1.5 text-gray-500 border border-gray-500/20 rounded-full text-xs hover:bg-slate-50 transition">
-          Buy now
-        </button>
-      </div> */}
+        <p className="line-clamp-2 text-sm text-gray-500">
+          {product?.description || "Discover more details on the product page."}
+        </p>
+        <p className="text-sm font-semibold text-primary">
+          {(currency || "$")}
+          {displayPrice.toFixed(2)}
+        </p>
+      </div>
     </div>
   );
 };

--- a/components/ProductCard.jsx
+++ b/components/ProductCard.jsx
@@ -6,13 +6,8 @@ import { Heart } from "lucide-react";
 import { useAppContext } from "@/context/AppContext";
 
 const ProductCard = ({ product }) => {
-  const {
-    currency,
-    router,
-    wishlist,
-    addToWishlist,
-    removeFromWishlist,
-  } = useAppContext();
+  const { currency, router, wishlist, addToWishlist, removeFromWishlist } =
+    useAppContext();
   const [wishlistAnimation, setWishlistAnimation] = useState("");
 
   const productId = useMemo(() => {
@@ -106,7 +101,7 @@ const ProductCard = ({ product }) => {
       onClick={handleCardClick}
       className="flex w-full max-w-[250px] cursor-pointer flex-col items-start"
     >
-      <div className="group relative flex h-80 w-full items-center justify-center overflow-hidden rounded-2xl bg-gray-50 shadow-poster transition">
+      <div className="group relative flex h-80 w-full items-center justify-center overflow-hidden bg-gray-50 shadow-poster transition">
         {previewImage ? (
           <Image
             src={previewImage}
@@ -125,9 +120,7 @@ const ProductCard = ({ product }) => {
 
         <button
           type="button"
-          aria-label={
-            isWishlisted ? "Remove from wishlist" : "Add to wishlist"
-          }
+          aria-label={isWishlisted ? "Remove from wishlist" : "Add to wishlist"}
           aria-pressed={isWishlisted}
           onClick={toggleWishlist}
           className="absolute top-3 right-3 flex cursor-pointer items-center justify-center rounded-full bg-white/90 p-2 text-gray-600 shadow-md transition-transform duration-200 hover:scale-110 hover:text-secondary active:scale-95"
@@ -142,7 +135,7 @@ const ProductCard = ({ product }) => {
         </button>
       </div>
 
-      <div className="mt-4 flex w-full flex-col gap-2 text-left">
+      {/* <div className="mt-4 flex w-full flex-col gap-2 text-left">
         <p className="truncate text-base font-semibold text-blackhex">
           {product?.name || product?.title || "Untitled Poster"}
         </p>
@@ -150,10 +143,10 @@ const ProductCard = ({ product }) => {
           {product?.description || "Discover more details on the product page."}
         </p>
         <p className="text-sm font-semibold text-primary">
-          {(currency || "$")}
+          {currency || "$"}
           {displayPrice.toFixed(2)}
         </p>
-      </div>
+      </div> */}
     </div>
   );
 };

--- a/models/Wishlist.js
+++ b/models/Wishlist.js
@@ -1,0 +1,37 @@
+import mongoose from "mongoose";
+
+const wishlistItemSchema = new mongoose.Schema(
+  {
+    product: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Product",
+      required: true,
+    },
+    addedAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  { _id: false }
+);
+
+const wishlistSchema = new mongoose.Schema(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      unique: true,
+    },
+    items: {
+      type: [wishlistItemSchema],
+      default: [],
+    },
+  },
+  { timestamps: true }
+);
+
+const Wishlist =
+  mongoose.models.Wishlist || mongoose.model("Wishlist", wishlistSchema);
+
+export default Wishlist;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "dotenv": "^17.2.3",
         "fuse.js": "^7.1.0",
         "inngest": "^3.40.1",
+        "lucide-react": "^0.545.0",
         "mongoose": "^8.16.4",
         "next": "^15.4.1",
         "nodemailer": "^7.0.6",
@@ -7885,6 +7886,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.545.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.545.0.tgz",
+      "integrity": "sha512-7r1/yUuflQDSt4f1bpn5ZAocyIxcTyVyBBChSVtBKn5M+392cPmI5YJMWOJKk/HUWGm5wg83chlAZtCcGbEZtw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/map-obj": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dotenv": "^17.2.3",
     "fuse.js": "^7.1.0",
     "inngest": "^3.40.1",
+    "lucide-react": "^0.545.0",
     "mongoose": "^8.16.4",
     "next": "^15.4.1",
     "nodemailer": "^7.0.6",


### PR DESCRIPTION
## Summary
- add a MongoDB-backed wishlist model and CRUD API routes for authenticated users
- wire the wishlist into the global AppContext with helper actions for fetching, adding, and removing items
- ensure wishlist data is populated with product details and synced with Clerk authentication flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e47ce5be3083268c6e57618502ed46