### PR TITLE
Improve shop layout and wishlist handling

### DIFF
--- a/app/api/wishlist/add/route.js
+++ b/app/api/wishlist/add/route.js
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import mongoose from "mongoose";
+import { getAuth } from "@clerk/nextjs/server";
+
+import connectDB from "@/config/db";
+import User from "@/models/User";
+import Wishlist from "@/models/Wishlist";
+
+export async function POST(request) {
+  console.log("[wishlist/add] Incoming request");
+
+  try {
+    const { userId } = getAuth(request);
+    console.log("[wishlist/add] userId from getAuth:", userId);
+
+    const body = await request.json().catch((error) => {
+      console.error("[wishlist/add] Failed to parse request body:", error);
+      throw new Error("Invalid JSON body");
+    });
+
+    const productId = body?.productId;
+    console.log("[wishlist/add] productId from body:", productId);
+
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, message: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    if (!productId) {
+      return NextResponse.json(
+        { success: false, message: "Product ID is required" },
+        { status: 400 }
+      );
+    }
+
+    await connectDB();
+
+    const user = await User.findOne({ userId });
+    console.log(
+      "[wishlist/add] User.findOne result:",
+      user ? { _id: user._id.toString(), userId: user.userId } : user
+    );
+
+    if (!user) {
+      return NextResponse.json(
+        { success: false, message: "User not found" },
+        { status: 404 }
+      );
+    }
+
+    let normalizedProductId;
+    try {
+      normalizedProductId = new mongoose.Types.ObjectId(productId);
+    } catch (error) {
+      console.error("[wishlist/add] Invalid productId ObjectId cast:", error);
+      return NextResponse.json(
+        { success: false, message: "Invalid product id" },
+        { status: 400 }
+      );
+    }
+
+    const existing = await Wishlist.findOne({
+      user: user._id,
+      product: normalizedProductId,
+    });
+    console.log(
+      "[wishlist/add] Wishlist.findOne result:",
+      existing
+        ? {
+            _id: existing._id.toString(),
+            user: existing.user.toString(),
+            product: existing.product.toString(),
+          }
+        : existing
+    );
+
+    if (existing) {
+      return NextResponse.json({ success: true, wishlist: existing });
+    }
+
+    const wishlist = await Wishlist.create({
+      user: user._id,
+      userId: user.userId,
+      product: normalizedProductId,
+    });
+
+    console.log("[wishlist/add] Created wishlist entry:", {
+      _id: wishlist._id.toString(),
+      user: wishlist.user.toString(),
+      product: wishlist.product.toString(),
+    });
+
+    return NextResponse.json({ success: true, wishlist }, { status: 201 });
+  } catch (error) {
+    console.error("WISHLIST ADD ERROR:", error);
+    return NextResponse.json(
+      { success: false, message: "Failed to add to wishlist" },
+      { status: 500 }
+    );
+  }
+}

--- a/components/ShopClient.jsx
+++ b/components/ShopClient.jsx
@@ -217,7 +217,7 @@ const ShopClient = ({ products }) => {
           </div>
 
           {filteredProducts.length > 0 ? (
-            <div className="grid grid-cols-2 gap-6 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+            <div className="grid grid-cols-2 gap-6 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 2xl:gap-8">
               {filteredProducts.map((product) => (
                 <ProductCard
                   key={product?._id ?? product?.productId}

--- a/context/AppContext.jsx
+++ b/context/AppContext.jsx
@@ -143,6 +143,34 @@ export const AppContextProvider = (props) => {
     }
   };
 
+  const addToWishlist = async (productId) => {
+    if (!productId) {
+      toast.error("Missing product information");
+      return;
+    }
+
+    if (!user) {
+      toast.error("Please sign in to save items to your wishlist");
+      return;
+    }
+
+    try {
+      const token = await getToken();
+      await axios.post(
+        "/api/wishlist/add",
+        { productId },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      toast.success("Added to wishlist");
+    } catch (error) {
+      toast.error(
+        error?.response?.data?.message ||
+          error.message ||
+          "Failed to add to wishlist"
+      );
+    }
+  };
+
   const updateCartQuantity = async (itemId, quantity) => {
     let cartData = structuredClone(cartItems);
     const existing = cartData[itemId];
@@ -235,6 +263,7 @@ export const AppContextProvider = (props) => {
     cartItems,
     setCartItems,
     addToCart,
+    addToWishlist,
     updateCartQuantity,
     getCartCount,
     getCartAmount,

--- a/models/Wishlist.js
+++ b/models/Wishlist.js
@@ -1,0 +1,30 @@
+import mongoose from "mongoose";
+
+const WishlistSchema = new mongoose.Schema(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+    userId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    product: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Product",
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+WishlistSchema.index({ user: 1, product: 1 }, { unique: true });
+WishlistSchema.index({ userId: 1, product: 1 }, { unique: true });
+
+export default mongoose.models.Wishlist ||
+  mongoose.model("Wishlist", WishlistSchema);


### PR DESCRIPTION
## Summary
- update the shop grid to keep four columns on laptop breakpoints while preserving five columns for ultra-wide displays
- add a Wishlist model and an API route that records detailed diagnostics before database writes
- propagate the Clerk authorization header from the client when adding items to the wishlist so the API receives the authenticated user

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4877426fc8326b678ce0654f9eb04