### PR TITLE
Integrate GA4 and Meta Pixel tracking

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,3 +1,4 @@
+import Script from "next/script";
 import "./globals.css";
 import { AppContextProvider } from "@/context/AppContext";
 import { Toaster } from "react-hot-toast";
@@ -26,12 +27,54 @@ export default function RootLayout({ children }) {
   return (
     <ClerkProvider>
       <html lang="en">
+        <head>
+          {/* Google Analytics 4 setup */}
+          <Script
+            async
+            src="https://www.googletagmanager.com/gtag/js?id=G-WS50WJJDNT"
+            strategy="afterInteractive"
+          />
+          <Script id="ga4" strategy="afterInteractive">
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', 'G-WS50WJJDNT');
+            `}
+          </Script>
+
+          {/* Meta (Facebook) Pixel setup */}
+          <Script id="facebook-pixel" strategy="afterInteractive">
+            {`
+              !function(f,b,e,v,n,t,s)
+              {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+              n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+              if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+              n.queue=[];t=b.createElement(e);t.async=!0;
+              t.src=v;s=b.getElementsByTagName(e)[0];
+              s.parentNode.insertBefore(t,s)}(window, document,'script',
+              'https://connect.facebook.net/en_US/fbevents.js');
+              fbq('init', '1120594359291706');
+              fbq('track', 'PageView');
+            `}
+          </Script>
+          <noscript>
+            <img
+              height="1"
+              width="1"
+              style={{ display: "none" }}
+              src="https://www.facebook.com/tr?id=1120594359291706&ev=PageView&noscript=1"
+              alt="Facebook pixel tracking"
+            />
+          </noscript>
+        </head>
         <body
           className={`${poppins.variable} font-sans text-blackhex antialiased`}
         >
+          {/* Global toast notifications */}
           <Toaster />
+          {/* Provide application context */}
           <AppContextProvider>
-            {" "}
             <div className="mx-auto w-full max-w-content px-6 md:px-8 lg:px-0">
               {children}
             </div>

--- a/components/examples/MetaPixelEventExample.jsx
+++ b/components/examples/MetaPixelEventExample.jsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { fbq } from "@/lib/metaPixel";
+
+// Example component showing how to trigger a custom Facebook Pixel event.
+export function MetaPixelEventExample() {
+  const handlePurchase = () => {
+    // Track a purchase event with custom value and currency metadata.
+    fbq("track", "Purchase", { value: 50, currency: "CAD" });
+  };
+
+  return (
+    <button
+      type="button"
+      className="rounded-md bg-black px-4 py-2 text-white"
+      onClick={handlePurchase}
+    >
+      Trigger Purchase Event
+    </button>
+  );
+}

--- a/lib/metaPixel.js
+++ b/lib/metaPixel.js
@@ -1,0 +1,7 @@
+// /lib/metaPixel.js
+// Safely proxy calls to the Facebook Pixel after the script has loaded.
+export const fbq = (...args) => {
+  if (typeof window !== "undefined" && typeof window.fbq === "function") {
+    window.fbq(...args);
+  }
+};


### PR DESCRIPTION
## Summary
- load Google Analytics 4 and Meta Pixel scripts in the app layout using afterInteractive strategy and noscript fallback
- add a reusable helper for safe fbq event triggering along with an example component demonstrating custom events

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68e48a74c9208326acd8398531d2ef5b