### PR TITLE
Harden promo validation

### DIFF
--- a/app/api/checkout/session/route.js
+++ b/app/api/checkout/session/route.js
@@ -1,0 +1,197 @@
+import Stripe from "stripe";
+import { NextResponse } from "next/server";
+
+const getBaseUrl = (request) => {
+  return (
+    process.env.NEXT_PUBLIC_URL ||
+    request.headers.get("origin") ||
+    "http://localhost:3000"
+  );
+};
+
+const normaliseCartItems = (cart = {}) => {
+  if (!Array.isArray(cart.items)) return [];
+
+  return cart.items
+    .map((item, index) => {
+      const quantity = Math.max(Number(item?.quantity ?? 1), 1);
+      const price = Math.max(Number(item?.price ?? 0), 0);
+      const unitAmountCents = Math.round(price * 100);
+
+      if (!Number.isFinite(unitAmountCents) || unitAmountCents < 0) {
+        return null;
+      }
+
+      const name =
+        item?.title || item?.name || item?.productName || `Item ${index + 1}`;
+
+      return {
+        name,
+        quantity,
+        unitAmountCents,
+      };
+    })
+    .filter(Boolean);
+};
+
+export async function POST(request) {
+  try {
+    const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+    if (!stripeSecretKey) {
+      return NextResponse.json(
+        { success: false, message: "Missing Stripe configuration" },
+        { status: 500 }
+      );
+    }
+
+    const stripe = new Stripe(stripeSecretKey);
+    const { cart = {}, promoCode, successUrl, cancelUrl } = await request.json();
+
+    const lineItems = normaliseCartItems(cart);
+    if (!lineItems.length) {
+      return NextResponse.json(
+        { success: false, message: "Cart is empty" },
+        { status: 400 }
+      );
+    }
+
+    const currency = (cart.currency || "cad").toLowerCase();
+    const shippingCost = Math.max(Number(cart.shippingCost ?? 0), 0);
+    const subtotalCents = lineItems.reduce(
+      (sum, item) => sum + item.unitAmountCents * item.quantity,
+      0
+    );
+    const shippingCents = Math.round(shippingCost * 100);
+    const originalTotalCents = subtotalCents + shippingCents;
+
+    let discountResult = {
+      valid: false,
+      discount: 0,
+      newTotal: Number((originalTotalCents / 100).toFixed(2)),
+      originalTotal: Number((originalTotalCents / 100).toFixed(2)),
+      promoType: null,
+      promoValue: null,
+    };
+
+    if (promoCode) {
+      try {
+        const validationResponse = await fetch(
+          `${getBaseUrl(request)}/api/promo/validate`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              code: promoCode,
+              cart: {
+                items: cart.items,
+                totalPrice: cart.totalPrice ?? subtotalCents / 100,
+                shippingCost,
+              },
+            }),
+          }
+        );
+
+        const body = await validationResponse.json();
+        if (validationResponse.ok && body?.valid) {
+          discountResult = body;
+        } else if (body?.message) {
+          console.warn("Promo validation failed:", body.message);
+        }
+      } catch (error) {
+        console.error("Promo validation request failed:", error);
+      }
+    }
+
+    let couponId;
+    if (
+      discountResult.valid &&
+      discountResult.discount > 0 &&
+      discountResult.promoType !== "shipping"
+    ) {
+      if (discountResult.promoType === "percent") {
+        const percentOff = Math.min(
+          Math.max(Number(discountResult.promoValue ?? 0), 0),
+          100
+        );
+        if (percentOff > 0) {
+          const coupon = await stripe.coupons.create({
+            percent_off: percentOff,
+            duration: "once",
+          });
+          couponId = coupon.id;
+        }
+      } else {
+        const amountOffCents = Math.round(Number(discountResult.discount) * 100);
+        if (amountOffCents > 0) {
+          const coupon = await stripe.coupons.create({
+            amount_off: amountOffCents,
+            currency,
+            duration: "once",
+          });
+          couponId = coupon.id;
+        }
+      }
+    }
+
+    const shouldWaiveShipping =
+      discountResult.valid &&
+      discountResult.promoType === "shipping" &&
+      shippingCents > 0;
+
+    const stripeLineItems = lineItems.map((item) => ({
+      price_data: {
+        currency,
+        product_data: { name: item.name },
+        unit_amount: item.unitAmountCents,
+      },
+      quantity: item.quantity,
+    }));
+
+    if (!shouldWaiveShipping && shippingCents > 0) {
+      stripeLineItems.push({
+        price_data: {
+          currency,
+          product_data: { name: "Shipping" },
+          unit_amount: shippingCents,
+        },
+        quantity: 1,
+      });
+    }
+
+    const session = await stripe.checkout.sessions.create({
+      line_items: stripeLineItems,
+      mode: "payment",
+      success_url: successUrl || `${getBaseUrl(request)}/checkout/success`,
+      cancel_url: cancelUrl || `${getBaseUrl(request)}/checkout/cancel`,
+      ...(couponId ? { discounts: [{ coupon: couponId }] } : {}),
+      ...(shouldWaiveShipping
+        ? {
+            shipping_options: [
+              {
+                shipping_rate_data: {
+                  type: "fixed_amount",
+                  display_name: "Free Shipping",
+                  fixed_amount: { amount: 0, currency },
+                },
+              },
+            ],
+          }
+        : {}),
+      metadata: {
+        promoCode: promoCode || "",
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      url: session.url,
+      promoApplied: discountResult.valid ? discountResult : null,
+    });
+  } catch (error) {
+    console.error("Checkout Session Error:", error);
+    return NextResponse.json(
+      { success: false, message: "Unable to create checkout session" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/promo/create/route.js
+++ b/app/api/promo/create/route.js
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import connectDB from "@/config/db";
+import Promo from "@/models/PromoModel";
+
+const sanitizeNumber = (value) => {
+  if (value === "" || value === null || value === undefined) return undefined;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : undefined;
+};
+
+export async function POST(request) {
+  try {
+    await connectDB();
+    const payload = await request.json();
+
+    const promoData = {
+      code: payload.code?.trim(),
+      type: payload.type,
+      condition: payload.condition ?? "none",
+      value: sanitizeNumber(payload.value) ?? 0,
+      minCartValue: sanitizeNumber(payload.minCartValue),
+      minQuantity: sanitizeNumber(payload.minQuantity),
+      expiresAt: payload.expiresAt ? new Date(payload.expiresAt) : undefined,
+      isActive:
+        typeof payload.isActive === "boolean" ? payload.isActive : true,
+    };
+
+    if (!promoData.code || !promoData.type || promoData.value < 0) {
+      return NextResponse.json(
+        { success: false, message: "Invalid promo payload" },
+        { status: 400 }
+      );
+    }
+
+    const promo = await Promo.create(promoData);
+    return NextResponse.json({ success: true, promo });
+  } catch (error) {
+    console.error("Promo Create Error:", error);
+
+    if (error.code === 11000) {
+      return NextResponse.json(
+        { success: false, message: "Promo code already exists" },
+        { status: 409 }
+      );
+    }
+
+    if (error.name === "ValidationError") {
+      return NextResponse.json(
+        { success: false, message: error.message },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      { success: false, message: "Failed to create promo" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/promo/validate/route.js
+++ b/app/api/promo/validate/route.js
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import connectDB from "@/config/db";
+import Promo from "@/models/PromoModel";
+import { applyPromo } from "@/lib/promoCode";
+
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_MAX_ATTEMPTS = 10;
+
+const getRateLimitStore = () => {
+  if (!globalThis.__promoRateLimitStore) {
+    globalThis.__promoRateLimitStore = new Map();
+  }
+  return globalThis.__promoRateLimitStore;
+};
+
+const getClientId = (request) => {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const [first] = forwardedFor.split(",");
+    if (first) return first.trim();
+  }
+  const realIp = request.headers.get("x-real-ip");
+  if (realIp) return realIp;
+  return request.headers.get("user-agent") || "unknown";
+};
+
+const isRateLimited = (request, code) => {
+  const store = getRateLimitStore();
+  const clientId = getClientId(request);
+  const key = `${clientId}:${code?.toLowerCase() ?? ""}`;
+  const now = Date.now();
+
+  const entry = store.get(key);
+
+  if (!entry || entry.expiresAt <= now) {
+    store.set(key, { count: 1, expiresAt: now + RATE_LIMIT_WINDOW_MS });
+    return false;
+  }
+
+  if (entry.count >= RATE_LIMIT_MAX_ATTEMPTS) {
+    return true;
+  }
+
+  entry.count += 1;
+  store.set(key, entry);
+  return false;
+};
+
+export async function POST(request) {
+  try {
+    const { code, cart } = await request.json();
+
+    if (!code) {
+      return NextResponse.json(
+        { valid: false, message: "Promo code required" },
+        { status: 400 }
+      );
+    }
+
+    if (isRateLimited(request, code)) {
+      return NextResponse.json(
+        { valid: false, message: "Too many attempts" },
+        { status: 429 }
+      );
+    }
+
+    await connectDB();
+
+    const promo = await Promo.findOne({ code: code.trim(), isActive: true }).lean();
+
+    if (!promo) {
+      return NextResponse.json({ valid: false, message: "Invalid code" });
+    }
+
+    if (promo.expiresAt && new Date(promo.expiresAt) < new Date()) {
+      return NextResponse.json({ valid: false, message: "Expired" });
+    }
+
+    const result = applyPromo(cart, promo);
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Promo Validate Error:", error);
+    return NextResponse.json(
+      { valid: false, message: "Server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/seller/discounts/page.jsx
+++ b/app/seller/discounts/page.jsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useState } from "react";
+import toast from "react-hot-toast";
+
+const defaultFormState = {
+  code: "",
+  type: "flat",
+  condition: "none",
+  value: "0",
+  minCartValue: "",
+  minQuantity: "",
+  expiresAt: "",
+  isActive: true,
+};
+
+const typeLabels = {
+  flat: "Flat Amount",
+  percent: "Percentage",
+  shipping: "Free Shipping",
+};
+
+const conditionLabels = {
+  none: "No Condition",
+  cartValue: "Minimum Cart Value",
+  quantity: "Minimum Quantity",
+};
+
+export default function DiscountsPage() {
+  const [form, setForm] = useState(defaultFormState);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleChange = (event) => {
+    const { name, value, type, checked } = event.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: type === "checkbox" ? checked : value,
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    if (!form.code.trim()) {
+      toast.error("Promo code is required");
+      return;
+    }
+
+    if (form.type !== "shipping" && Number(form.value) <= 0) {
+      toast.error("Value must be greater than zero");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const payload = {
+        code: form.code.trim().toUpperCase(),
+        type: form.type,
+        condition: form.condition,
+        value: form.type === "shipping" ? 0 : Number(form.value),
+        minCartValue:
+          form.condition === "cartValue" && form.minCartValue !== ""
+            ? Number(form.minCartValue)
+            : undefined,
+        minQuantity:
+          form.condition === "quantity" && form.minQuantity !== ""
+            ? Number(form.minQuantity)
+            : undefined,
+        expiresAt: form.expiresAt || undefined,
+        isActive: form.isActive,
+      };
+
+      const response = await fetch("/api/promo/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok || !data.success) {
+        throw new Error(data.message || "Failed to create promo");
+      }
+
+      toast.success("Promo created!");
+      setForm(defaultFormState);
+    } catch (error) {
+      toast.error(error.message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const showMinCartValue = form.condition === "cartValue";
+  const showMinQuantity = form.condition === "quantity";
+
+  return (
+    <div className="p-8 max-w-3xl mx-auto w-full">
+      <h1 className="text-3xl font-semibold mb-6">Create Promo Code</h1>
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-6 bg-white shadow-sm rounded-lg p-6 border border-gray-100"
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col gap-2 text-sm font-medium">
+            Code
+            <input
+              name="code"
+              placeholder="SUMMER25"
+              className="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/50 uppercase"
+              value={form.code}
+              onChange={handleChange}
+              required
+            />
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm font-medium">
+            Type
+            <select
+              name="type"
+              className="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/50"
+              value={form.type}
+              onChange={handleChange}
+            >
+              {Object.entries(typeLabels).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm font-medium">
+            Condition
+            <select
+              name="condition"
+              className="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/50"
+              value={form.condition}
+              onChange={handleChange}
+            >
+              {Object.entries(conditionLabels).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm font-medium">
+            Value
+            <input
+              name="value"
+              type="number"
+              min={0}
+              step="0.01"
+              placeholder="10"
+              className="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/50"
+              value={form.value}
+              onChange={handleChange}
+              disabled={form.type === "shipping"}
+            />
+            <span className="text-xs text-gray-500">
+              {form.type === "percent"
+                ? "Percentage discount (e.g. 15 for 15%)"
+                : form.type === "flat"
+                ? "Flat discount amount"
+                : "Shipping will be waived when applied"}
+            </span>
+          </label>
+
+          {showMinCartValue && (
+            <label className="flex flex-col gap-2 text-sm font-medium">
+              Minimum Cart Value
+              <input
+                name="minCartValue"
+                type="number"
+                min={0}
+                step="0.01"
+                placeholder="100"
+                className="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/50"
+                value={form.minCartValue}
+                onChange={handleChange}
+              />
+            </label>
+          )}
+
+          {showMinQuantity && (
+            <label className="flex flex-col gap-2 text-sm font-medium">
+              Minimum Quantity
+              <input
+                name="minQuantity"
+                type="number"
+                min={0}
+                placeholder="3"
+                className="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/50"
+                value={form.minQuantity}
+                onChange={handleChange}
+              />
+            </label>
+          )}
+
+          <label className="flex flex-col gap-2 text-sm font-medium">
+            Expires At
+            <input
+              name="expiresAt"
+              type="datetime-local"
+              className="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/50"
+              value={form.expiresAt}
+              onChange={handleChange}
+            />
+          </label>
+
+          <label className="flex items-center gap-3 text-sm font-medium">
+            <input
+              type="checkbox"
+              name="isActive"
+              checked={form.isActive}
+              onChange={handleChange}
+              className="h-4 w-4"
+            />
+            Active Promo
+          </label>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            className="bg-primary text-white px-5 py-2 rounded-md disabled:opacity-60 disabled:cursor-not-allowed"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? "Saving..." : "Save Promo"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setForm(defaultFormState)}
+            className="px-5 py-2 rounded-md border border-gray-300 text-gray-700"
+          >
+            Reset
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/lib/promoCode.js
+++ b/lib/promoCode.js
@@ -1,0 +1,108 @@
+const isExpired = (expiresAt) => {
+  if (!expiresAt) return false;
+  const expiryDate = new Date(expiresAt);
+  if (Number.isNaN(expiryDate.getTime())) {
+    return false;
+  }
+  return expiryDate.getTime() < Date.now();
+};
+
+export const applyPromo = (cart = {}, promo = {}) => {
+  if (!cart || typeof cart !== "object") {
+    return { valid: false, message: "Invalid cart", discount: 0, newTotal: 0 };
+  }
+
+  if (!promo || typeof promo !== "object") {
+    const shippingCost = Number(cart.shippingCost ?? 0);
+    const cartValue = Number(cart.totalPrice ?? 0);
+    const originalTotal = Math.max(cartValue + shippingCost, 0);
+    return {
+      valid: false,
+      message: "Invalid promo",
+      discount: 0,
+      newTotal: originalTotal,
+      originalTotal,
+    };
+  }
+
+  if (isExpired(promo?.expiresAt)) {
+    const shippingCost = Math.max(Number(cart.shippingCost ?? 0), 0);
+    const cartValue = Math.max(Number(cart.totalPrice ?? 0), 0);
+    const originalTotal = cartValue + shippingCost;
+
+    return {
+      valid: false,
+      message: "Expired",
+      discount: 0,
+      newTotal: originalTotal,
+      originalTotal,
+    };
+  }
+
+  const { type, condition, value, minCartValue, minQuantity } = promo;
+  const cartValue = Math.max(Number(cart.totalPrice ?? 0), 0);
+  const shippingCost = Math.max(Number(cart.shippingCost ?? 0), 0);
+  const quantity = Array.isArray(cart.items)
+    ? cart.items.reduce((sum, item) => sum + Number(item?.quantity ?? 0), 0)
+    : 0;
+  const originalTotal = cartValue + shippingCost;
+
+  if (!type) {
+    return {
+      valid: false,
+      message: "Promo type missing",
+      discount: 0,
+      newTotal: originalTotal,
+      originalTotal,
+    };
+  }
+
+  if (condition === "cartValue" && Number(minCartValue ?? 0) > cartValue) {
+    return {
+      valid: false,
+      message: "Cart value too low",
+      discount: 0,
+      newTotal: originalTotal,
+      originalTotal,
+    };
+  }
+
+  if (condition === "quantity" && Number(minQuantity ?? 0) > quantity) {
+    return {
+      valid: false,
+      message: "Not enough items",
+      discount: 0,
+      newTotal: originalTotal,
+      originalTotal,
+    };
+  }
+
+  let discount = 0;
+  const numericValue = Number(value ?? 0);
+
+  if (type === "flat") {
+    discount = Math.max(numericValue, 0);
+  } else if (type === "percent") {
+    discount = Math.max((originalTotal * numericValue) / 100, 0);
+  } else if (type === "shipping") {
+    discount = shippingCost;
+  }
+
+  if (!Number.isFinite(discount)) {
+    discount = 0;
+  }
+
+  const cappedDiscount = Math.min(discount, originalTotal);
+  const newTotal = Math.max(originalTotal - cappedDiscount, 0);
+
+  return {
+    valid: true,
+    discount: Number(cappedDiscount.toFixed(2)),
+    newTotal: Number(newTotal.toFixed(2)),
+    originalTotal: Number(originalTotal.toFixed(2)),
+    message: `Applied ${promo.code}`,
+    promoCode: promo.code,
+    promoType: type,
+    promoValue: numericValue,
+  };
+};

--- a/models/PromoModel.js
+++ b/models/PromoModel.js
@@ -1,0 +1,26 @@
+import mongoose from "mongoose";
+
+const PromoSchema = new mongoose.Schema(
+  {
+    code: { type: String, required: true, unique: true, trim: true },
+    type: {
+      type: String,
+      enum: ["flat", "percent", "shipping"],
+      required: true,
+    },
+    condition: {
+      type: String,
+      enum: ["none", "cartValue", "quantity"],
+      default: "none",
+    },
+    value: { type: Number, required: true, min: 0 },
+    minCartValue: { type: Number, min: 0 },
+    minQuantity: { type: Number, min: 0 },
+    expiresAt: { type: Date },
+    isActive: { type: Boolean, default: true },
+  },
+  { timestamps: true }
+);
+
+const Promo = mongoose.models.Promo || mongoose.model("Promo", PromoSchema);
+export default Promo;


### PR DESCRIPTION
## Summary
- add Promo mongoose model and shared promo application helper
- create promo creation/validation APIs and seller dashboard form for managing codes
- integrate promo validation and Stripe coupon orchestration into checkout session flow
- harden promo usage by checking expiry inside shared logic, defaulting Stripe currency to CAD, and adding a lightweight validation rate limit

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e53104f9b4832698fc186581ffcca9