### PR TITLE
Add guest checkout guestId helper and unit tests

### DIFF
--- a/__tests__/guestUtils.test.js
+++ b/__tests__/guestUtils.test.js
@@ -1,0 +1,91 @@
+import { getOrCreateGuestId, isGuestIdExpired, __internal } from '../lib/guestUtils';
+
+describe('guestUtils', () => {
+  const originalCrypto = globalThis.crypto;
+  const originalLocalStorage = globalThis.localStorage;
+  let randomUUIDMock;
+
+  const setLocalStorageValue = (key, value) => {
+    if (!globalThis.localStorage) {
+      throw new Error('localStorage is not defined in the test environment');
+    }
+    globalThis.localStorage.setItem(key, value);
+  };
+
+  beforeEach(() => {
+    // Ensure a clean slate for each test run.
+    if (!globalThis.localStorage) {
+      globalThis.localStorage = window.localStorage;
+    }
+    globalThis.localStorage.clear();
+
+    randomUUIDMock = jest.fn(() => `mock-uuid-${Math.random().toString(16).slice(2)}`);
+
+    if (!globalThis.crypto) {
+      globalThis.crypto = {};
+    }
+    globalThis.crypto.randomUUID = randomUUIDMock;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    globalThis.localStorage?.clear();
+
+    if (originalCrypto?.randomUUID) {
+      globalThis.crypto = originalCrypto;
+    } else {
+      delete globalThis.crypto;
+    }
+
+    if (originalLocalStorage) {
+      globalThis.localStorage = originalLocalStorage;
+    }
+  });
+
+  test('isGuestIdExpired returns true for timestamps older than 30 days', () => {
+    const now = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    const oldTimestamp = new Date(now - __internal.GUEST_ID_RETENTION_MS - 1).toISOString();
+
+    expect(isGuestIdExpired(oldTimestamp)).toBe(true);
+  });
+
+  test('generates a new guest ID when none exists', () => {
+    randomUUIDMock.mockReturnValueOnce('mock-uuid-new');
+
+    const id = getOrCreateGuestId();
+    expect(id).toBe('mock-uuid-new');
+
+    const stored = globalThis.localStorage.getItem(__internal.GUEST_ID_STORAGE_KEY);
+    const parsed = JSON.parse(stored);
+    expect(parsed).toMatchObject({ id: 'mock-uuid-new' });
+    expect(randomUUIDMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('reuses an existing guest ID when it is still valid', () => {
+    const now = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    const freshTimestamp = new Date(now - __internal.GUEST_ID_RETENTION_MS / 2).toISOString();
+    const storedPayload = JSON.stringify({ id: 'existing-uuid', createdAt: freshTimestamp });
+    setLocalStorageValue(__internal.GUEST_ID_STORAGE_KEY, storedPayload);
+
+    const id = getOrCreateGuestId();
+    expect(id).toBe('existing-uuid');
+    expect(randomUUIDMock).not.toHaveBeenCalled();
+  });
+
+  test('regenerates a guest ID when the stored value is expired', () => {
+    const now = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    const staleTimestamp = new Date(now - __internal.GUEST_ID_RETENTION_MS - 1).toISOString();
+    const storedPayload = JSON.stringify({ id: 'stale-uuid', createdAt: staleTimestamp });
+    setLocalStorageValue(__internal.GUEST_ID_STORAGE_KEY, storedPayload);
+    randomUUIDMock.mockReturnValueOnce('fresh-uuid');
+
+    const id = getOrCreateGuestId();
+    expect(id).toBe('fresh-uuid');
+    expect(randomUUIDMock).toHaveBeenCalledTimes(1);
+    const stored = globalThis.localStorage.getItem(__internal.GUEST_ID_STORAGE_KEY);
+    expect(stored).toEqual(expect.stringContaining('fresh-uuid'));
+  });
+});

--- a/lib/guestUtils.js
+++ b/lib/guestUtils.js
@@ -1,0 +1,81 @@
+const GUEST_ID_STORAGE_KEY = 'posterGenius.guest';
+const GUEST_ID_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+/**
+ * Determines whether the provided guest ID creation timestamp is older than the
+ * retention window.
+ *
+ * @param {string | number | Date | undefined | null} createdAt - The timestamp representing when the guest ID was created.
+ * @returns {boolean} True when the timestamp is older than 30 days, false otherwise.
+ */
+export function isGuestIdExpired(createdAt) {
+  if (!createdAt) {
+    return true;
+  }
+
+  const createdTime = new Date(createdAt).getTime();
+  if (Number.isNaN(createdTime)) {
+    return true;
+  }
+
+  return Date.now() - createdTime > GUEST_ID_RETENTION_MS;
+}
+
+/**
+ * Retrieves a guest ID from localStorage or creates one if missing/expired.
+ *
+ * @returns {string | null} The guest ID if available on the client, otherwise null.
+ */
+export function getOrCreateGuestId() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const storage = window.localStorage;
+  if (!storage) {
+    return null;
+  }
+
+  try {
+    const existingValue = storage.getItem(GUEST_ID_STORAGE_KEY);
+    if (existingValue) {
+      const parsed = JSON.parse(existingValue);
+      if (parsed?.id && !isGuestIdExpired(parsed.createdAt)) {
+        console.log('[guestUtils] Reusing existing guestId:', parsed.id);
+        return parsed.id;
+      }
+    }
+  } catch (error) {
+    console.warn('[guestUtils] Failed to parse stored guestId. Creating a new one.', error);
+  }
+
+  const newId = window.crypto?.randomUUID?.();
+  if (!newId) {
+    console.error('[guestUtils] Unable to generate guestId: window.crypto.randomUUID is unavailable.');
+    return null;
+  }
+
+  const createdAt = new Date().toISOString();
+  const payload = JSON.stringify({ id: newId, createdAt });
+  storage.setItem(GUEST_ID_STORAGE_KEY, payload);
+  console.log('[guestUtils] Created new guestId:', newId, 'at', createdAt);
+
+  return newId;
+}
+
+export const __internal = {
+  GUEST_ID_STORAGE_KEY,
+  GUEST_ID_RETENTION_MS,
+};
+
+/**
+ * Manual verification:
+ * 1. Trigger getOrCreateGuestId() inside any client component or in DevTools (window.getOrCreateGuestId?).
+ * 2. Inspect localStorage for the `posterGenius.guest` entry and confirm it contains `{ id, createdAt }`.
+ * 3. Reload within 30 days to observe reuse logs in the console.
+ *
+ * Automated verification with Jest:
+ * 1. Ensure dev dependencies exist by running:
+ *    `npm install --save-dev jest @testing-library/react @testing-library/jest-dom jest-environment-jsdom`.
+ * 2. Run tests with `npx jest` to execute coverage in `__tests__/guestUtils.test.js`.
+ */


### PR DESCRIPTION
## Summary
- add a guest ID utility that manages persistence in localStorage with expiration safeguards
- log reuse and creation events while guarding against server-side execution
- add Jest coverage to confirm creation, reuse, and expiration behaviors

## Testing
- `npx jest __tests__/guestUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e59433c8688326bbd83903d66cfe1c