### PR TITLE
feat: add guest-aware cart CRUD endpoints

### DIFF
--- a/app/api/cart/add/route.js
+++ b/app/api/cart/add/route.js
@@ -1,0 +1,113 @@
+import connectDB from "@/config/db";
+import Cart from "@/models/Cart";
+import { getAuth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+const ALLOWED_STRING_FIELDS = [
+  "_id",
+  "productId",
+  "title",
+  "imageUrl",
+  "slug",
+  "dimensions",
+  "format",
+];
+
+function sanitizeCartItem(item = {}) {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+
+  const sanitized = {};
+
+  for (const field of ALLOWED_STRING_FIELDS) {
+    if (item[field] !== undefined && item[field] !== null) {
+      sanitized[field] = String(item[field]);
+    }
+  }
+
+  if (item.price !== undefined) {
+    const price = Number(item.price);
+    sanitized.price = Number.isFinite(price) ? price : 0;
+  }
+
+  const quantity = Number(item.quantity ?? 0);
+  if (!Number.isFinite(quantity) || quantity <= 0) {
+    return null;
+  }
+  sanitized.quantity = quantity;
+
+  return sanitized;
+}
+
+function buildIdentifier(userId, guestId) {
+  if (userId) return { userId };
+  if (guestId) return { guestId };
+  return null;
+}
+
+export async function POST(request) {
+  try {
+    const { userId } = getAuth(request);
+    const body = await request.json();
+    const { guestId: bodyGuestId, itemKey, itemData } = body || {};
+
+    const headerGuestId = request.headers.get("x-guest-id");
+    const guestId = bodyGuestId ?? headerGuestId ?? null;
+
+    if (guestId && typeof guestId !== "string") {
+      return NextResponse.json(
+        { success: false, message: "Invalid guestId" },
+        { status: 400 }
+      );
+    }
+
+    if (!userId && !guestId) {
+      return NextResponse.json(
+        { success: false, message: "Missing cart identifier" },
+        { status: 400 }
+      );
+    }
+
+    if (!itemKey || typeof itemKey !== "string") {
+      return NextResponse.json(
+        { success: false, message: "Invalid cart item key" },
+        { status: 400 }
+      );
+    }
+
+    const sanitizedItem = sanitizeCartItem(itemData);
+    if (!sanitizedItem) {
+      return NextResponse.json(
+        { success: false, message: "Invalid cart item payload" },
+        { status: 400 }
+      );
+    }
+
+    await connectDB();
+
+    const query = buildIdentifier(userId, guestId);
+    let cart = await Cart.findOne(query);
+    if (!cart) {
+      cart = await Cart.create({ ...query, items: {} });
+    }
+
+    cart.items[itemKey] = sanitizedItem;
+    cart.markModified("items");
+    await cart.save();
+
+    return NextResponse.json({ success: true, cartItems: cart.items });
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: error.message },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Manual verification:
+ * 1. For signed-in users, send a POST request to `/api/cart/add` with `{ itemKey, itemData }`.
+ * 2. For guests, include `guestId` in the JSON body (and/or `x-guest-id` header) and repeat step 1.
+ * 3. Inspect MongoDB to ensure the `items` object is updated with sanitized data only.
+ */

--- a/app/api/cart/delete/route.js
+++ b/app/api/cart/delete/route.js
@@ -1,0 +1,71 @@
+import connectDB from "@/config/db";
+import Cart from "@/models/Cart";
+import { getAuth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+function buildIdentifier(userId, guestId) {
+  if (userId) return { userId };
+  if (guestId) return { guestId };
+  return null;
+}
+
+export async function POST(request) {
+  try {
+    const { userId } = getAuth(request);
+    const body = await request.json();
+    const { guestId: bodyGuestId, itemKey } = body || {};
+
+    const headerGuestId = request.headers.get("x-guest-id");
+    const guestId = bodyGuestId ?? headerGuestId ?? null;
+
+    if (guestId && typeof guestId !== "string") {
+      return NextResponse.json(
+        { success: false, message: "Invalid guestId" },
+        { status: 400 }
+      );
+    }
+
+    if (!userId && !guestId) {
+      return NextResponse.json(
+        { success: false, message: "Missing cart identifier" },
+        { status: 400 }
+      );
+    }
+
+    if (!itemKey || typeof itemKey !== "string") {
+      return NextResponse.json(
+        { success: false, message: "Invalid cart item key" },
+        { status: 400 }
+      );
+    }
+
+    await connectDB();
+
+    const query = buildIdentifier(userId, guestId);
+    const cart = await Cart.findOne(query);
+
+    if (!cart) {
+      return NextResponse.json({ success: true, cartItems: {} });
+    }
+
+    if (cart.items && cart.items[itemKey]) {
+      delete cart.items[itemKey];
+      cart.markModified("items");
+      await cart.save();
+    }
+
+    return NextResponse.json({ success: true, cartItems: cart.items });
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: error.message },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Manual verification:
+ * 1. Add a cart item (via `/api/cart/add`) for a user or guest.
+ * 2. Call `/api/cart/delete` with the same identifier and `itemKey`.
+ * 3. Confirm the response omits the removed entry and MongoDB reflects the deletion.
+ */

--- a/app/api/cart/get/route.js
+++ b/app/api/cart/get/route.js
@@ -1,18 +1,49 @@
 import connectDB from "@/config/db";
-import User from "@/models/User";
+import Cart from "@/models/Cart";
 import { getAuth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
+
+function extractGuestId(request) {
+  const headerGuestId = request.headers.get("x-guest-id");
+  if (headerGuestId) return headerGuestId;
+  return request.nextUrl.searchParams.get("guestId");
+}
 
 export async function GET(request) {
   try {
     const { userId } = getAuth(request);
+    const guestId = extractGuestId(request);
+
+    if (guestId && typeof guestId !== "string") {
+      return NextResponse.json(
+        { success: false, message: "Invalid guestId" },
+        { status: 400 }
+      );
+    }
+
+    if (!userId && !guestId) {
+      return NextResponse.json({ success: true, cartItems: {} });
+    }
 
     await connectDB();
-    const user = await User.findOne({ userId });
+    const query = userId ? { userId } : { guestId };
+    const cart = await Cart.findOne(query);
 
-    const { cartItems } = user;
-    return NextResponse.json({ success: true, cartItems });
+    return NextResponse.json({
+      success: true,
+      cartItems: cart?.items || {},
+    });
   } catch (error) {
-    return NextResponse.json({ success: false, message: error.message });
+    return NextResponse.json(
+      { success: false, message: error.message },
+      { status: 500 }
+    );
   }
 }
+
+/**
+ * Manual verification:
+ * 1. Create a cart document tied to either a userId or guestId in MongoDB.
+ * 2. For authenticated requests, call `/api/cart/get` with a valid Clerk session.
+ * 3. For guests, send `x-guest-id` header (or `?guestId=`) and confirm the stored items are returned.
+ */

--- a/context/AppContext.jsx
+++ b/context/AppContext.jsx
@@ -5,6 +5,11 @@ import { useRouter } from "next/navigation";
 import { createContext, useContext, useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { augmentProductWithPricing } from "@/lib/pricing";
+import {
+  getOrCreateGuestId,
+  isGuestIdExpired,
+  __internal as guestInternal,
+} from "@/lib/guestUtils";
 
 export const AppContext = createContext();
 export const useAppContext = () => useContext(AppContext);
@@ -22,6 +27,10 @@ export const AppContextProvider = (props) => {
   const [isAdmin, setIsAdmin] = useState(false);
   const [cartItems, setCartItems] = useState({});
   const [wishlist, setWishlist] = useState([]);
+  const [activeGuestId, setActiveGuestId] = useState(null);
+
+  const guestStorageKey =
+    guestInternal?.GUEST_ID_STORAGE_KEY || "posterGenius.guest";
 
   const normalizeWishlist = (source) => {
     if (!source) return [];
@@ -58,6 +67,56 @@ export const AppContextProvider = (props) => {
     return augmentProductWithPricing(normalized);
   };
 
+  const peekStoredGuestId = () => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    try {
+      const raw = window.localStorage.getItem(guestStorageKey);
+      if (!raw) {
+        return null;
+      }
+
+      const parsed = JSON.parse(raw);
+      if (!parsed?.id || isGuestIdExpired(parsed.createdAt)) {
+        window.localStorage.removeItem(guestStorageKey);
+        return null;
+      }
+
+      return parsed.id;
+    } catch (error) {
+      console.warn("[AppContext] Failed to parse stored guestId", error);
+      return null;
+    }
+  };
+
+  const prepareCartRequest = async ({ createGuestIfMissing = false } = {}) => {
+    if (user) {
+      const token = await getToken();
+      return {
+        headers: { Authorization: `Bearer ${token}` },
+        guestId: null,
+      };
+    }
+
+    let guestId = peekStoredGuestId();
+    if (!guestId && createGuestIfMissing) {
+      guestId = getOrCreateGuestId();
+    }
+
+    if (!guestId) {
+      return { headers: {}, guestId: null };
+    }
+
+    setActiveGuestId((prev) => (prev === guestId ? prev : guestId));
+
+    return {
+      headers: { "x-guest-id": guestId },
+      guestId,
+    };
+  };
+
   const fetchProductData = async () => {
     try {
       const { data } = await axios.get("/api/product/list");
@@ -68,6 +127,28 @@ export const AppContextProvider = (props) => {
       }
     } catch (error) {
       toast.error(error.message || "Failed to load products");
+    }
+  };
+
+  const fetchCart = async ({ createGuestIfMissing = false } = {}) => {
+    try {
+      const { headers, guestId } = await prepareCartRequest({
+        createGuestIfMissing,
+      });
+
+      if (!user && !guestId) {
+        setCartItems({});
+        return;
+      }
+
+      const { data } = await axios.get("/api/cart/get", { headers });
+      if (data.success) {
+        setCartItems(data.cartItems || {});
+      } else {
+        toast.error(data.message || "Failed to load cart");
+      }
+    } catch (error) {
+      toast.error(error.message || "Failed to load cart");
     }
   };
 
@@ -82,7 +163,6 @@ export const AppContextProvider = (props) => {
 
       if (data.success) {
         setUserData(data.user);
-        setCartItems(data.user.cartItems || {});
       } else {
         toast.error(data.message || "Failed to load user");
       }
@@ -115,15 +195,41 @@ export const AppContextProvider = (props) => {
 
   const addToCart = async (payload) => {
     let cartData = structuredClone(cartItems);
+    let itemKey = null;
+    let itemRecord = null;
 
     if (typeof payload === "string") {
       const itemId = payload; // primitive id path
       const existing = cartData[itemId];
-      cartData[itemId] = existing
+      const nextQuantity = existing
         ? typeof existing === "object"
-          ? { ...existing, quantity: (existing.quantity || 0) + 1 }
-          : existing + 1
+          ? (existing.quantity || 0) + 1
+          : Number(existing) + 1
         : 1;
+
+      const productInfo = products.find(
+        (p) => (p.productId || p._id?.toString?.() || p._id) === itemId
+      );
+
+      const fallbackPrice =
+        productInfo?.pricing?.defaultPhysicalFinalPrice ??
+        productInfo?.finalPrice ??
+        productInfo?.price ??
+        0;
+
+      const normalized = {
+        productId: itemId,
+        title: productInfo?.title ?? productInfo?.name ?? "",
+        imageUrl: productInfo?.imageUrl ?? productInfo?.images?.[0] ?? "",
+        price: Number(fallbackPrice) || 0,
+        quantity: Number(nextQuantity),
+        slug: productInfo?.slug ?? "",
+        dimensions: productInfo?.dimensions ?? "",
+      };
+
+      cartData[itemId] = normalized;
+      itemKey = itemId;
+      itemRecord = normalized;
     } else if (payload && typeof payload === "object") {
       let p = { ...payload };
 
@@ -151,6 +257,7 @@ export const AppContextProvider = (props) => {
 
       if (existing && typeof existing === "object") {
         existing.quantity = (existing.quantity || 0) + Number(p.quantity ?? 1);
+        itemRecord = existing;
       } else {
         cartData[key] = {
           productId: p.productId,
@@ -162,23 +269,41 @@ export const AppContextProvider = (props) => {
           format: p.format,
           dimensions: p.dimensions,
         };
+        itemRecord = cartData[key];
       }
+
+      itemKey = key;
     }
 
     setCartItems(cartData);
 
-    if (user) {
-      try {
-        const token = await getToken();
-        await axios.post(
-          "/api/cart/update",
-          { cartData },
-          { headers: { Authorization: `Bearer ${token}` } }
-        );
-        toast.success("cart updated successfully");
-      } catch (error) {
-        toast.error(error.message || "Failed to update cart");
+    if (!itemKey || !itemRecord || typeof itemRecord !== "object") {
+      return;
+    }
+
+    try {
+      const { headers, guestId } = await prepareCartRequest({
+        createGuestIfMissing: !user,
+      });
+
+      if (!user && !guestId) {
+        console.warn("[AppContext] Unable to persist cart for guest without guestId");
+        return;
       }
+
+      await axios.post(
+        "/api/cart/add",
+        {
+          itemKey,
+          itemData: itemRecord,
+          ...(guestId ? { guestId } : {}),
+        },
+        { headers }
+      );
+
+      toast.success("cart updated successfully");
+    } catch (error) {
+      toast.error(error.message || "Failed to update cart");
     }
   };
 
@@ -191,23 +316,66 @@ export const AppContextProvider = (props) => {
     } else if (typeof existing === "object") {
       existing.quantity = Number(quantity);
     } else {
-      cartData[itemId] = Number(quantity);
+      const productInfo = products.find(
+        (p) => (p.productId || p._id?.toString?.() || p._id) === itemId
+      );
+
+      const fallbackPrice =
+        productInfo?.pricing?.defaultPhysicalFinalPrice ??
+        productInfo?.finalPrice ??
+        productInfo?.price ??
+        0;
+
+      cartData[itemId] = {
+        productId: itemId,
+        title: productInfo?.title ?? productInfo?.name ?? "",
+        imageUrl: productInfo?.imageUrl ?? productInfo?.images?.[0] ?? "",
+        price: Number(fallbackPrice) || 0,
+        quantity: Number(quantity),
+        slug: productInfo?.slug ?? "",
+        dimensions: productInfo?.dimensions ?? "",
+      };
     }
 
     setCartItems(cartData);
 
-    if (user) {
-      try {
-        const token = await getToken();
-        await axios.post(
-          "/api/cart/update",
-          { cartData },
-          { headers: { Authorization: `Bearer ${token}` } }
-        );
-        toast.success("cart updated successfully");
-      } catch (error) {
-        toast.error(error.message || "Failed to update cart");
+    const isRemoval = quantity === 0;
+    const itemRecord = cartData[itemId];
+
+    try {
+      const { headers, guestId } = await prepareCartRequest({
+        createGuestIfMissing: !user && quantity > 0,
+      });
+
+      if (!user && !guestId) {
+        console.warn("[AppContext] Unable to persist cart for guest without guestId");
+        return;
       }
+
+      if (isRemoval) {
+        await axios.post(
+          "/api/cart/delete",
+          {
+            itemKey: itemId,
+            ...(guestId ? { guestId } : {}),
+          },
+          { headers }
+        );
+      } else if (itemRecord && typeof itemRecord === "object") {
+        await axios.post(
+          "/api/cart/add",
+          {
+            itemKey: itemId,
+            itemData: itemRecord,
+            ...(guestId ? { guestId } : {}),
+          },
+          { headers }
+        );
+      }
+
+      toast.success("cart updated successfully");
+    } catch (error) {
+      toast.error(error.message || "Failed to update cart");
     }
   };
 
@@ -317,10 +485,20 @@ export const AppContextProvider = (props) => {
     if (user) {
       fetchUserData();
       fetchWishlist();
+      fetchCart({ createGuestIfMissing: false });
+      setActiveGuestId(null);
     } else {
       setIsAdmin(false);
       setWishlist([]);
+      const existingGuestId = peekStoredGuestId();
+      setActiveGuestId(existingGuestId);
+      if (existingGuestId) {
+        fetchCart({ createGuestIfMissing: false });
+      } else {
+        setCartItems({});
+      }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user]);
 
   const value = {
@@ -334,8 +512,10 @@ export const AppContextProvider = (props) => {
     fetchUserData,
     products,
     fetchProductData,
+    fetchCart,
     cartItems,
     setCartItems,
+    activeGuestId,
     addToCart,
     updateCartQuantity,
     getCartCount,
@@ -352,3 +532,10 @@ export const AppContextProvider = (props) => {
     <AppContext.Provider value={value}>{props.children}</AppContext.Provider>
   );
 };
+
+/**
+ * Manual verification:
+ * 1. Log out, add products to the cart, and confirm `/api/cart/add` receives a guestId.
+ * 2. Refresh the page and ensure `/api/cart/get` restores the same guest cart.
+ * 3. Log in and verify the authenticated cart remains separate from the guest cart.
+ */

--- a/models/Cart.js
+++ b/models/Cart.js
@@ -2,8 +2,8 @@ import mongoose from "mongoose";
 
 const cartSchema = new mongoose.Schema(
   {
-    userId: { type: String },
-    guestId: { type: String },
+    userId: { type: String, required: false },
+    guestId: { type: String, required: false },
     items: { type: Object, default: {} },
   },
   { minimize: false, timestamps: true }
@@ -13,9 +13,34 @@ cartSchema.pre("validate", function (next) {
   if (!this.userId && !this.guestId) {
     return next(new Error("userId or guestId is required"));
   }
+
+  if (this.userId && this.guestId) {
+    return next(new Error("Cart cannot reference both userId and guestId"));
+  }
+
   next();
 });
+
+cartSchema.index(
+  { userId: 1 },
+  { unique: true, partialFilterExpression: { userId: { $exists: true, $type: "string" } } }
+);
+
+cartSchema.index(
+  { guestId: 1 },
+  { unique: true, partialFilterExpression: { guestId: { $exists: true, $type: "string" } } }
+);
 
 const Cart = mongoose.models.cart || mongoose.model("cart", cartSchema);
 
 export default Cart;
+
+/**
+ * Manual verification:
+ * 1. Run `node` in the project root and `await mongoose.connect(process.env.MONGODB_URI)`.
+ * 2. Create sample carts via `Cart.create({ userId: "user_123", items: {} })` and `Cart.create({ guestId: "guest_123", items: {} })`.
+ * 3. Attempt to set both identifiers on a single doc to observe the validation error.
+ *
+ * Automated verification:
+ * 1. Use Jest or your preferred runner to insert fixtures and ensure duplicate userId/guestId carts fail to save.
+ */


### PR DESCRIPTION
## Summary
- extend the Cart model with guestId validation and indexes to allow either user or guest carts
- add REST endpoints for /api/cart/add, /api/cart/get, and /api/cart/delete that work for authenticated users and guests
- update the AppContext cart helpers to request a guestId when needed and call the new APIs while keeping wishlist behind authentication

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e59829c56883269d33c464ad0554f4