### PR TITLE
Add Clerk guards for guest wishlist interactions

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -7,12 +7,24 @@ import Image from "next/image";
 import { useClerk, UserButton } from "@clerk/nextjs";
 import TopBanner from "@/components/TopBanner";
 import { Heart } from "lucide-react";
+import toast from "react-hot-toast";
 
 const Navbar = () => {
-  const { isAdmin, router, user, getCartCount, wishlist } = useAppContext();
+  const { isAdmin, router, user, getCartCount, getWishlistCount } =
+    useAppContext();
   const { openSignIn } = useClerk();
   const cartCount = getCartCount();
-  const wishlistCount = wishlist?.length ?? 0;
+  const wishlistCount = getWishlistCount?.() ?? 0;
+
+  const handleWishlistNavigation = () => {
+    if (user) {
+      router.push("/wishlist");
+      return;
+    }
+
+    toast.error("Please sign in to save your wishlist.");
+    openSignIn?.();
+  };
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const closeMenu = () => setIsMenuOpen(false);
@@ -93,7 +105,7 @@ const Navbar = () => {
           {/* wishlist */}
           <button
             type="button"
-            onClick={() => router.push("/wishlist")}
+            onClick={handleWishlistNavigation}
             className="relative flex items-center justify-center text-gray-600 transition-transform duration-200 hover:scale-110 hover:text-secondary active:scale-95"
             aria-label="View wishlist"
           >
@@ -179,7 +191,7 @@ const Navbar = () => {
         <div className="flex items-center lg:hidden gap-3">
           <button
             type="button"
-            onClick={() => router.push("/wishlist")}
+            onClick={handleWishlistNavigation}
             className="relative flex items-center justify-center text-gray-600 transition-transform duration-200 hover:scale-110 hover:text-secondary active:scale-95"
             aria-label="View wishlist"
           >

--- a/components/ProductOverlay.jsx
+++ b/components/ProductOverlay.jsx
@@ -5,6 +5,17 @@ import { useAppContext } from "@/context/AppContext";
 
 export default function ProductOverlay({ product }) {
   const { addToCart, removeFromWishlist } = useAppContext();
+  const resolveProductId = () => {
+    if (
+      typeof product?._id === "object" &&
+      product?._id !== null &&
+      typeof product?._id.toString === "function"
+    ) {
+      return product._id.toString();
+    }
+
+    return product?._id ?? product?.productId ?? product?.id ?? "";
+  };
   const [open, setOpen] = useState(false);
 
   return (
@@ -50,7 +61,10 @@ export default function ProductOverlay({ product }) {
           <button
             onClick={(e) => {
               e.stopPropagation();
-              removeFromWishlist(product._id);
+              const productId = resolveProductId();
+              if (productId) {
+                removeFromWishlist(productId);
+              }
               setOpen(false);
             }}
             className="w-full text-left px-4 py-2 hover:bg-gray-50 text-sm text-red-500"

--- a/context/AppContext.jsx
+++ b/context/AppContext.jsx
@@ -171,6 +171,20 @@ export const AppContextProvider = (props) => {
     }
   };
 
+  const promptWishlistSignIn = () => {
+    toast.error("Please sign in to save your wishlist.");
+    openSignIn?.();
+  };
+
+  const ensureWishlistAccess = () => {
+    if (user) {
+      return true;
+    }
+
+    promptWishlistSignIn();
+    return false;
+  };
+
   const fetchWishlist = async () => {
     if (!user) {
       setWishlist([]);
@@ -380,8 +394,7 @@ export const AppContextProvider = (props) => {
   };
 
   const addToWishlist = async (productId) => {
-    if (!user) {
-      openSignIn?.();
+    if (!ensureWishlistAccess()) {
       return;
     }
 
@@ -409,8 +422,7 @@ export const AppContextProvider = (props) => {
   };
 
   const removeFromWishlist = async (productId) => {
-    if (!user) {
-      openSignIn?.();
+    if (!ensureWishlistAccess()) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- add a shared guard in the app context to require authentication before performing wishlist actions
- prompt guests from the navbar and wishlist page with Clerk sign-in and an explanatory toast instead of calling wishlist APIs
- normalize wishlist removals in the product overlay to ensure product IDs resolve correctly on guest flows

## Testing
- npx jest *(fails: jest-environment-jsdom package missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b111c6f48326bf735f19f8a43c01