### PR TITLE
Add guest checkout address persistence

### DIFF
--- a/app/api/guest/get-address/route.js
+++ b/app/api/guest/get-address/route.js
@@ -1,0 +1,45 @@
+import connectDB from "@/config/db";
+import GuestAddress from "@/models/GuestAddress";
+import { NextResponse } from "next/server";
+
+function extractGuestId(request) {
+  const headerGuestId = request.headers.get("x-guest-id");
+  if (headerGuestId) return headerGuestId;
+  return request.nextUrl.searchParams.get("guestId");
+}
+
+export async function GET(request) {
+  try {
+    const guestId = extractGuestId(request);
+
+    if (!guestId) {
+      return NextResponse.json({ success: true, address: null });
+    }
+
+    if (typeof guestId !== "string") {
+      return NextResponse.json(
+        { success: false, message: "Invalid guestId" },
+        { status: 400 }
+      );
+    }
+
+    await connectDB();
+
+    const address = await GuestAddress.findOne({ guestId });
+
+    return NextResponse.json({ success: true, address });
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: error.message },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Manual verification:
+ * 1. Create a guest address document in MongoDB tied to a guestId.
+ * 2. Send a GET request to `/api/guest/get-address` with either the `x-guest-id`
+ *    header or `?guestId=` query param and confirm the address is returned.
+ * 3. Request without a guestId and confirm `{ address: null }` is returned.
+ */

--- a/app/api/guest/save-address/route.js
+++ b/app/api/guest/save-address/route.js
@@ -1,0 +1,87 @@
+import connectDB from "@/config/db";
+import GuestAddress from "@/models/GuestAddress";
+import { NextResponse } from "next/server";
+
+const REQUIRED_FIELDS = [
+  "fullName",
+  "email",
+  "phone",
+  "street",
+  "city",
+  "postalCode",
+  "country",
+  "province",
+];
+
+function normalizeAddressPayload(addressData = {}) {
+  return REQUIRED_FIELDS.reduce((acc, field) => {
+    const value = addressData[field];
+    acc[field] = typeof value === "string" ? value.trim() : "";
+    return acc;
+  }, {});
+}
+
+function validateRequestBody(body) {
+  if (!body || typeof body !== "object") {
+    return { valid: false, message: "Invalid request payload" };
+  }
+
+  const { guestId, addressData } = body;
+
+  if (!guestId || typeof guestId !== "string") {
+    return { valid: false, message: "guestId is required" };
+  }
+
+  if (!addressData || typeof addressData !== "object") {
+    return { valid: false, message: "addressData is required" };
+  }
+
+  const normalized = normalizeAddressPayload(addressData);
+  const missing = REQUIRED_FIELDS.filter((field) => !normalized[field]);
+
+  if (missing.length > 0) {
+    return {
+      valid: false,
+      message: `Missing required fields: ${missing.join(", ")}`,
+    };
+  }
+
+  return { valid: true, guestId, address: normalized };
+}
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { valid, message, guestId, address } = validateRequestBody(body);
+
+    if (!valid) {
+      return NextResponse.json(
+        { success: false, message },
+        { status: 400 }
+      );
+    }
+
+    await connectDB();
+
+    const updatedAddress = await GuestAddress.findOneAndUpdate(
+      { guestId },
+      { $set: { guestId, ...address } },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+
+    return NextResponse.json({ success: true, address: updatedAddress });
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: error.message },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Manual verification:
+ * 1. Generate a guestId via the storefront (localStorage `posterGenius.guest`).
+ * 2. POST to `/api/guest/save-address` with `{ guestId, addressData: { ... } }` and confirm
+ *    the response contains the persisted address document.
+ * 3. Inspect the `guestAddresses` collection to ensure the document is upserted per guest.
+ */

--- a/app/checkout/page.jsx
+++ b/app/checkout/page.jsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import axios from "axios";
+import toast from "react-hot-toast";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import OrderSummary from "@/components/OrderSummary";
+import { useAppContext } from "@/context/AppContext";
+
+const EMPTY_GUEST_ADDRESS = {
+  fullName: "",
+  email: "",
+  phone: "",
+  street: "",
+  city: "",
+  postalCode: "",
+  country: "",
+  province: "",
+};
+
+const inputCls =
+  "px-3 py-3 rounded-md w-full text-blackhex placeholder-gray-500 " +
+  "border border-gray-300 focus:border-primary focus:ring-2 focus:ring-secondary/40 outline-none " +
+  "transition-colors duration-200";
+
+const fieldOrder = [
+  { name: "fullName", label: "Full name", type: "text", autoComplete: "name" },
+  {
+    name: "email",
+    label: "Email address",
+    type: "email",
+    autoComplete: "email",
+  },
+  {
+    name: "phone",
+    label: "Phone number",
+    type: "tel",
+    autoComplete: "tel",
+  },
+  {
+    name: "street",
+    label: "Street address",
+    type: "text",
+    autoComplete: "street-address",
+  },
+  { name: "city", label: "City", type: "text", autoComplete: "address-level2" },
+  {
+    name: "province",
+    label: "Province / State",
+    type: "text",
+    autoComplete: "address-level1",
+  },
+  {
+    name: "postalCode",
+    label: "Postal code",
+    type: "text",
+    autoComplete: "postal-code",
+  },
+  { name: "country", label: "Country", type: "text", autoComplete: "country" },
+];
+
+const CheckoutPage = () => {
+  const { user, ensureGuestId, fetchGuestAddress } = useAppContext();
+  const [formValues, setFormValues] = useState(EMPTY_GUEST_ADDRESS);
+  const [guestId, setGuestId] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isPrefilling, setIsPrefilling] = useState(false);
+
+  useEffect(() => {
+    if (user) return;
+
+    let ignore = false;
+
+    const prefillGuestAddress = async () => {
+      setIsPrefilling(true);
+      const result = await fetchGuestAddress({ createGuestIfMissing: true });
+      if (ignore) return;
+
+      if (result?.guestId) {
+        setGuestId(result.guestId);
+      }
+
+      if (result?.address) {
+        setFormValues((prev) => ({
+          ...prev,
+          ...fieldOrder.reduce((acc, field) => {
+            if (result.address[field.name]) {
+              acc[field.name] = result.address[field.name];
+            }
+            return acc;
+          }, {}),
+        }));
+      }
+
+      setIsPrefilling(false);
+    };
+
+    prefillGuestAddress();
+
+    return () => {
+      ignore = true;
+    };
+  }, [user, fetchGuestAddress]);
+
+  const isFormDisabled = useMemo(() => user != null, [user]);
+
+  const handleChange = (field) => (event) => {
+    const { value } = event.target;
+    setFormValues((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    if (user) {
+      toast.success("You are signed in. Manage addresses from your account.");
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      const activeGuestId = guestId || (await ensureGuestId());
+
+      if (!activeGuestId) {
+        toast.error("Unable to create guest session. Please refresh and try again.");
+        return;
+      }
+
+      const { data } = await axios.post("/api/guest/save-address", {
+        guestId: activeGuestId,
+        addressData: formValues,
+      });
+
+      if (data?.success) {
+        setGuestId(activeGuestId);
+        if (data.address) {
+          setFormValues((prev) => ({
+            ...prev,
+            ...fieldOrder.reduce((acc, field) => {
+              if (data.address[field.name]) {
+                acc[field.name] = data.address[field.name];
+              }
+              return acc;
+            }, {}),
+          }));
+        }
+        toast.success("Address saved for guest checkout");
+      } else {
+        toast.error(data?.message || "Failed to save address");
+      }
+    } catch (error) {
+      toast.error(
+        error?.response?.data?.message || error.message || "Failed to save address"
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Navbar />
+      <div className="px-6 md:px-16 lg:px-32 py-12 flex flex-col-reverse lg:flex-row gap-12">
+        <div className="flex-1">
+          <h1 className="text-3xl font-semibold text-blackhex mb-6">
+            Guest <span className="text-primary">Checkout Details</span>
+          </h1>
+          {user ? (
+            <div className="bg-secondary/10 border border-secondary/30 rounded-lg p-6 text-blackhex">
+              <p className="font-medium">You are currently signed in.</p>
+              <p className="text-sm text-gray-600 mt-2">
+                Please use your saved addresses from the checkout summary or manage them on
+                the Add Address page.
+              </p>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              {fieldOrder.map(({ name, label, type, autoComplete }) => (
+                <div key={name} className="flex flex-col gap-2">
+                  <label htmlFor={name} className="text-sm font-medium text-gray-700">
+                    {label}
+                  </label>
+                  <input
+                    id={name}
+                    name={name}
+                    type={type}
+                    autoComplete={autoComplete}
+                    className={inputCls}
+                    value={formValues[name]}
+                    onChange={handleChange(name)}
+                    disabled={isSubmitting || isPrefilling || isFormDisabled}
+                    required
+                  />
+                </div>
+              ))}
+              <button
+                type="submit"
+                disabled={isSubmitting || isPrefilling}
+                className="w-full h-12 rounded-full font-semibold text-white bg-primary hover:bg-tertiary active:scale-[0.99] shadow-md shadow-primary/20 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                {isSubmitting ? "Saving..." : "Save guest address"}
+              </button>
+              <p className="text-xs text-gray-500">
+                Your contact details are only used to fulfill this order. We will remember them
+                for this browser session using your guest ID.
+              </p>
+            </form>
+          )}
+        </div>
+        <div className="w-full lg:max-w-md">
+          <OrderSummary />
+        </div>
+      </div>
+      <Footer />
+    </>
+  );
+};
+
+export default CheckoutPage;

--- a/context/AppContext.jsx
+++ b/context/AppContext.jsx
@@ -117,6 +117,40 @@ export const AppContextProvider = (props) => {
     };
   };
 
+  const ensureGuestId = async () => {
+    const { guestId } = await prepareCartRequest({
+      createGuestIfMissing: true,
+    });
+    return guestId;
+  };
+
+  const fetchGuestAddress = async ({ createGuestIfMissing = false } = {}) => {
+    try {
+      const { headers, guestId } = await prepareCartRequest({
+        createGuestIfMissing,
+      });
+
+      if (!guestId) {
+        return { guestId: null, address: null };
+      }
+
+      const { data } = await axios.get("/api/guest/get-address", { headers });
+
+      if (data.success) {
+        return { guestId, address: data.address || null };
+      }
+
+      console.warn(
+        "[AppContext] Failed to fetch guest address:",
+        data?.message
+      );
+      return { guestId, address: null };
+    } catch (error) {
+      console.error("[AppContext] Error fetching guest address", error);
+      return { guestId: null, address: null };
+    }
+  };
+
   const fetchProductData = async () => {
     try {
       const { data } = await axios.get("/api/product/list");
@@ -528,6 +562,8 @@ export const AppContextProvider = (props) => {
     cartItems,
     setCartItems,
     activeGuestId,
+    ensureGuestId,
+    fetchGuestAddress,
     addToCart,
     updateCartQuantity,
     getCartCount,

--- a/models/GuestAddress.js
+++ b/models/GuestAddress.js
@@ -1,0 +1,22 @@
+import mongoose from "mongoose";
+
+const guestAddressSchema = new mongoose.Schema(
+  {
+    guestId: { type: String, required: true, unique: true, index: true },
+    fullName: { type: String, required: true },
+    email: { type: String, required: true },
+    phone: { type: String, required: true },
+    street: { type: String, required: true },
+    city: { type: String, required: true },
+    postalCode: { type: String, required: true },
+    country: { type: String, required: true },
+    province: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+const GuestAddress =
+  mongoose.models.GuestAddress ||
+  mongoose.model("GuestAddress", guestAddressSchema);
+
+export default GuestAddress;


### PR DESCRIPTION
## Summary
- add guest address model and API routes for saving and retrieving guest checkout details
- expose guest helper utilities in the app context and build a guest checkout form page
- prefill guest checkout fields from MongoDB and persist updates for repeat visits

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5b5f60c0483268ef33541a1423de7