### PR TITLE
Guest session order support, claim-guest endpoint, and Track Order → My Orders renaming

### DIFF
--- a/app/api/download-link/route.js
+++ b/app/api/download-link/route.js
@@ -21,9 +21,12 @@ export async function GET(request) {
     const orderId = sanitizeIdentifier(searchParams.get("orderId"), {
       maxLength: 64,
     });
+    const guestId = sanitizeIdentifier(request.headers.get("x-guest-id"), {
+      maxLength: 128,
+    });
 
     if (!userId) {
-      if (!accessToken && !(lookupToken && orderId)) {
+      if (!guestId && !accessToken && !(lookupToken && orderId)) {
         return NextResponse.json(
           { success: false, message: "Unauthorized" },
           { status: 401 }
@@ -61,6 +64,8 @@ export async function GET(request) {
     };
     const identityQuery = userId
       ? { userId }
+      : guestId
+      ? { guestId }
       : lookupToken && orderId
       ? {
           _id: orderId,

--- a/app/api/order/claim-guest/route.js
+++ b/app/api/order/claim-guest/route.js
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { auth, currentUser } from "@clerk/nextjs/server";
+import connectDB from "@/config/db";
+import Order from "@/models/Order";
+import { sanitizeIdentifier } from "@/lib/security/input";
+
+export async function POST(request) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, message: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const guestId = sanitizeIdentifier(body?.guestId, { maxLength: 128 });
+    const clerkUser = await currentUser();
+    const emailSet = new Set(
+      (clerkUser?.emailAddresses || [])
+        .map((entry) => String(entry?.emailAddress || "").trim().toLowerCase())
+        .filter(Boolean)
+    );
+
+    await connectDB();
+
+    const matchers = [{ userId: { $exists: false } }, { userId: null }];
+    const ownershipClauses = [];
+
+    if (guestId) {
+      ownershipClauses.push({ guestId });
+    }
+
+    if (emailSet.size > 0) {
+      const emailRegexMatchers = Array.from(emailSet).map(
+        (email) => new RegExp(`^${email.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "i")
+      );
+      ownershipClauses.push(
+        { customerEmail: { $in: emailRegexMatchers } },
+        { "shippingAddressSnapshot.email": { $in: emailRegexMatchers } }
+      );
+    }
+
+    if (ownershipClauses.length === 0) {
+      return NextResponse.json({ success: true, linkedCount: 0 });
+    }
+
+    const result = await Order.updateMany(
+      {
+        $and: [{ $or: matchers }, { $or: ownershipClauses }],
+      },
+      {
+        $set: { userId },
+        $unset: { guestId: "" },
+      }
+    );
+
+    return NextResponse.json({
+      success: true,
+      linkedCount: result.modifiedCount || 0,
+    });
+  } catch (error) {
+    console.error("[order/claim-guest] Failed to claim guest orders", error);
+    return NextResponse.json(
+      { success: false, message: "Unable to link guest orders right now." },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/order/list/route.js
+++ b/app/api/order/list/route.js
@@ -4,23 +4,31 @@ import connectDB from "@/config/db";
 import Order from "@/models/Order";
 import "@/models/Product"; // register Product model for populate
 import "@/models/Address";
+import { sanitizeIdentifier } from "@/lib/security/input";
 
 export async function GET(request) {
   try {
     const { userId } = getAuth(request);
-    if (!userId) {
+    const guestId = sanitizeIdentifier(request.headers.get("x-guest-id"), {
+      maxLength: 128,
+    });
+
+    if (!userId && !guestId) {
       console.error("❌ Unauthorized fetch attempt");
       return NextResponse.json(
         { success: false, message: "Unauthorized" },
         { status: 401 }
       );
     }
-    console.log("🔑 Fetching orders for user:", userId);
+
+    console.log("🔑 Fetching orders for identity:", { userId, guestId });
 
     await connectDB();
     console.log("✅ DB connected in list route");
 
-    const orders = await Order.find({ userId })
+    const orders = await Order.find(
+      userId ? { userId } : { guestId }
+    )
       .sort({ date: -1 })
       .populate("items.product") // 👈 fetch full product docs
       .populate("digitalDownloads.product")

--- a/app/checkout/page.jsx
+++ b/app/checkout/page.jsx
@@ -320,8 +320,8 @@ export default function CheckoutPage() {
                     <p className="mt-2 text-sm leading-6 text-stone-600">
                       We use these details to fulfill your order, send your
                       confirmation, and let you retrieve guest purchases later from{" "}
-                      <Link href="/track-order" className="font-semibold text-primary">
-                        Track Order
+                      <Link href="/my-orders" className="font-semibold text-primary">
+                        My Orders
                       </Link>
                       .
                     </p>
@@ -363,7 +363,7 @@ export default function CheckoutPage() {
                       <p>Secure payment is handled by Stripe.</p>
                       <p className="mt-1">
                         Physical orders receive shipping updates. Digital orders
-                        can be retrieved from Track Order or downloaded from the
+                        can be retrieved from My Orders or downloaded from the
                         order page after purchase.
                       </p>
                     </div>

--- a/app/my-orders/MyOrdersClient.jsx
+++ b/app/my-orders/MyOrdersClient.jsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import axios from "axios";
 import toast from "react-hot-toast";
@@ -28,7 +27,8 @@ function resolveProductId(item) {
 export default function MyOrdersClient() {
   const pathname = usePathname();
   const router = useRouter();
-  const { getToken, user, setCartItems, fetchCart, currency } = useAppContext();
+  const { getToken, user, setCartItems, fetchCart, currency, ensureGuestId } =
+    useAppContext();
   const searchParams = useSearchParams();
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -65,11 +65,6 @@ export default function MyOrdersClient() {
         if (data?.success) {
           setCartItems({});
           await fetchCart({ createGuestIfMissing: false });
-
-          if (!user && data?.orderAccessUrl) {
-            router.replace(data.orderAccessUrl);
-            return;
-          }
 
           if (!data?.orderReady) {
             router.replace(pathname || "/my-orders");
@@ -119,14 +114,21 @@ export default function MyOrdersClient() {
       try {
         setLoading(true);
 
-        if (!user) {
-          if (!ignore) setOrders([]);
-          return;
+        const headers = {};
+        if (user) {
+          const token = await getToken();
+          headers.Authorization = `Bearer ${token}`;
+        } else {
+          const guestId = await ensureGuestId();
+          if (!guestId) {
+            if (!ignore) setOrders([]);
+            return;
+          }
+          headers["x-guest-id"] = guestId;
         }
 
-        const token = await getToken();
         const { data } = await axios.get("/api/order/list", {
-          headers: { Authorization: `Bearer ${token}` },
+          headers,
         });
 
         if (!ignore) {
@@ -154,9 +156,9 @@ export default function MyOrdersClient() {
     return () => {
       ignore = true;
     };
-  }, [confirming, getToken, user]);
+  }, [confirming, ensureGuestId, getToken, user]);
 
-  const downloadItem = async (item, order) => {
+  const downloadItem = async (item) => {
     const productId = resolveProductId(item);
     if (!productId) {
       toast.error("Download unavailable for this item");
@@ -166,8 +168,20 @@ export default function MyOrdersClient() {
     try {
       setDownloading(productId);
       const params = new URLSearchParams({ productId });
+      const headers = {};
 
-      const { data } = await axios.get(`/api/download-link?${params.toString()}`);
+      if (!user) {
+        const guestId = await ensureGuestId();
+        if (!guestId) {
+          toast.error("Guest session expired. Please sign in to recover this order.");
+          return;
+        }
+        headers["x-guest-id"] = guestId;
+      }
+
+      const { data } = await axios.get(`/api/download-link?${params.toString()}`, {
+        headers,
+      });
       if (data?.success && data?.url) {
         window.location.href = data.url;
       } else {
@@ -197,25 +211,6 @@ export default function MyOrdersClient() {
           {confirming || loading ? (
             <div className="py-12">
               <Loading />
-            </div>
-          ) : !user ? (
-            <div className="mt-8 rounded-2xl border border-stone-200 bg-white p-8 shadow-sm">
-              <h2 className="text-xl font-semibold text-blackhex">
-                Guest order access
-              </h2>
-              <p className="mt-3 max-w-2xl text-sm text-stone-600">
-                Guest orders are now accessed one order at a time using your email
-                address and order number. This keeps download and tracking access
-                scoped to the exact order you requested.
-              </p>
-              <div className="mt-6">
-                <Link
-                  href="/track-order"
-                  className="inline-flex h-11 items-center justify-center rounded-full bg-primary px-5 text-sm font-semibold text-white"
-                >
-                  Go to Track Order
-                </Link>
-              </div>
             </div>
           ) : orders.length === 0 ? (
             <div className="mt-8 rounded-2xl border border-dashed border-gray-300 bg-white p-8 text-sm text-gray-600">
@@ -309,7 +304,7 @@ export default function MyOrdersClient() {
                               {canDownload && (
                                 <button
                                   type="button"
-                                  onClick={() => downloadItem(item, order)}
+                                  onClick={() => downloadItem(item)}
                                   disabled={!productId || downloading === productId}
                                   className="rounded-full bg-primary px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
                                 >

--- a/components/GuestCheckoutSummary.jsx
+++ b/components/GuestCheckoutSummary.jsx
@@ -637,7 +637,7 @@ export default function GuestCheckoutSummary({
         </button>
         <p className="mt-3 text-center text-xs leading-5 text-stone-500">
           Secure payment handled by Stripe. Guest buyers can retrieve orders any
-          time from Track Order using email plus order number.
+          time from My Orders in this browser session.
         </p>
       </div>
     </div>

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -36,7 +36,6 @@ const Navbar = () => {
     { href: "/", label: "Home" },
     { href: "/shop", label: "Shop" },
     { href: "/videos", label: "How It Works" },
-    { href: "/track-order", label: "Track Order" },
     { href: "/about-us", label: "About Us" },
     { href: "/contact-us", label: "Contact" },
   ];

--- a/context/AppContext.jsx
+++ b/context/AppContext.jsx
@@ -614,6 +614,15 @@ export const AppContextProvider = (props) => {
           const token = await getToken();
           if (token) {
             await axios.post(
+              "/api/order/claim-guest",
+              { guestId: guestIdToMerge },
+              {
+                headers: {
+                  Authorization: `Bearer ${token}`,
+                },
+              }
+            );
+            await axios.post(
               "/api/cart/merge",
               { guestId: guestIdToMerge },
               {

--- a/middleware.ts
+++ b/middleware.ts
@@ -184,6 +184,13 @@ export default function middleware(request: NextRequest) {
     return redirectToPrimaryDomain(request);
   }
 
+  if (request.nextUrl.pathname.startsWith("/track-order")) {
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.pathname = "/my-orders";
+    redirectUrl.search = "";
+    return NextResponse.redirect(redirectUrl, 307);
+  }
+
   return clerkHandler(request);
 }
 


### PR DESCRIPTION
### Motivation
- Allow guest buyers to access orders and digital downloads within a browser session using a persistent `guestId` and to merge/link those guest orders to a user account on login.
- Replace legacy single-order "Track Order" flow with a persistent "My Orders" experience in the app and keep old routes redirecting for compatibility.

### Description
- Added a new API `POST /api/order/claim-guest` that links orders owned by a `guestId` or guest emails to the authenticated `userId` and unsets `guestId` on matched orders.
- Enabled guest session support by accepting an `x-guest-id` header in `GET /api/order/list` and `GET /api/download-link` so guest identities can retrieve lists and download links without signing in.
- Updated the front-end `MyOrdersClient` to use `ensureGuestId` when unauthenticated, send `x-guest-id` for list/download requests, and removed the old guest-only Track Order UI in favor of the `My Orders` client view.
- On login, the app now calls `POST /api/order/claim-guest` before cart merge to attach guest orders to the authenticated account; the middleware also redirects `/track-order` requests to `/my-orders` and UI text/links were updated accordingly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e16abf5ce48326bf7075f9ef0aaf24)