### PR TITLE
Add guest order support: claim-guest API, guest headers, UI updates, and provider refactor

### DIFF
--- a/app/api/download-link/route.js
+++ b/app/api/download-link/route.js
@@ -21,9 +21,12 @@ export async function GET(request) {
     const orderId = sanitizeIdentifier(searchParams.get("orderId"), {
       maxLength: 64,
     });
+    const guestId = sanitizeIdentifier(request.headers.get("x-guest-id"), {
+      maxLength: 128,
+    });
 
     if (!userId) {
-      if (!accessToken && !(lookupToken && orderId)) {
+      if (!guestId && !accessToken && !(lookupToken && orderId)) {
         return NextResponse.json(
           { success: false, message: "Unauthorized" },
           { status: 401 }
@@ -61,6 +64,8 @@ export async function GET(request) {
     };
     const identityQuery = userId
       ? { userId }
+      : guestId
+      ? { guestId }
       : lookupToken && orderId
       ? {
           _id: orderId,

--- a/app/api/order/claim-guest/route.js
+++ b/app/api/order/claim-guest/route.js
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { auth, currentUser } from "@clerk/nextjs/server";
+import connectDB from "@/config/db";
+import Order from "@/models/Order";
+import { sanitizeIdentifier } from "@/lib/security/input";
+
+export async function POST(request) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, message: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const guestId = sanitizeIdentifier(body?.guestId, { maxLength: 128 });
+    const clerkUser = await currentUser();
+    const emailSet = new Set(
+      (clerkUser?.emailAddresses || [])
+        .map((entry) => String(entry?.emailAddress || "").trim().toLowerCase())
+        .filter(Boolean)
+    );
+
+    await connectDB();
+
+    const matchers = [{ userId: { $exists: false } }, { userId: null }];
+    const ownershipClauses = [];
+
+    if (guestId) {
+      ownershipClauses.push({ guestId });
+    }
+
+    if (emailSet.size > 0) {
+      const emailRegexMatchers = Array.from(emailSet).map(
+        (email) => new RegExp(`^${email.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "i")
+      );
+      ownershipClauses.push(
+        { customerEmail: { $in: emailRegexMatchers } },
+        { "shippingAddressSnapshot.email": { $in: emailRegexMatchers } }
+      );
+    }
+
+    if (ownershipClauses.length === 0) {
+      return NextResponse.json({ success: true, linkedCount: 0 });
+    }
+
+    const result = await Order.updateMany(
+      {
+        $and: [{ $or: matchers }, { $or: ownershipClauses }],
+      },
+      {
+        $set: { userId },
+        $unset: { guestId: "" },
+      }
+    );
+
+    return NextResponse.json({
+      success: true,
+      linkedCount: result.modifiedCount || 0,
+    });
+  } catch (error) {
+    console.error("[order/claim-guest] Failed to claim guest orders", error);
+    return NextResponse.json(
+      { success: false, message: "Unable to link guest orders right now." },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/order/list/route.js
+++ b/app/api/order/list/route.js
@@ -4,23 +4,31 @@ import connectDB from "@/config/db";
 import Order from "@/models/Order";
 import "@/models/Product"; // register Product model for populate
 import "@/models/Address";
+import { sanitizeIdentifier } from "@/lib/security/input";
 
 export async function GET(request) {
   try {
     const { userId } = getAuth(request);
-    if (!userId) {
+    const guestId = sanitizeIdentifier(request.headers.get("x-guest-id"), {
+      maxLength: 128,
+    });
+
+    if (!userId && !guestId) {
       console.error("❌ Unauthorized fetch attempt");
       return NextResponse.json(
         { success: false, message: "Unauthorized" },
         { status: 401 }
       );
     }
-    console.log("🔑 Fetching orders for user:", userId);
+
+    console.log("🔑 Fetching orders for identity:", { userId, guestId });
 
     await connectDB();
     console.log("✅ DB connected in list route");
 
-    const orders = await Order.find({ userId })
+    const orders = await Order.find(
+      userId ? { userId } : { guestId }
+    )
       .sort({ date: -1 })
       .populate("items.product") // 👈 fetch full product docs
       .populate("digitalDownloads.product")

--- a/app/checkout/page.jsx
+++ b/app/checkout/page.jsx
@@ -320,8 +320,8 @@ export default function CheckoutPage() {
                     <p className="mt-2 text-sm leading-6 text-stone-600">
                       We use these details to fulfill your order, send your
                       confirmation, and let you retrieve guest purchases later from{" "}
-                      <Link href="/track-order" className="font-semibold text-primary">
-                        Track Order
+                      <Link href="/my-orders" className="font-semibold text-primary">
+                        My Orders
                       </Link>
                       .
                     </p>
@@ -363,7 +363,7 @@ export default function CheckoutPage() {
                       <p>Secure payment is handled by Stripe.</p>
                       <p className="mt-1">
                         Physical orders receive shipping updates. Digital orders
-                        can be retrieved from Track Order or downloaded from the
+                        can be retrieved from My Orders or downloaded from the
                         order page after purchase.
                       </p>
                     </div>

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,11 +1,9 @@
 import Image from "next/image";
 import Script from "next/script";
 import "./globals.css";
-import { AppContextProvider } from "@/context/AppContext";
-import { Toaster } from "react-hot-toast";
-import { ClerkProvider } from "@clerk/nextjs";
 import { Poppins } from "next/font/google";
 import { getOptimizedImageProps } from "@/lib/imageUtils";
+import Providers from "./providers";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -16,7 +14,6 @@ const poppins = Poppins({
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com";
-
 export const metadata = {
   icons: {
     icon: "/PG.svg", // Path to your favicon.ico in the public directory
@@ -31,9 +28,8 @@ export const metadata = {
 
 export default function RootLayout({ children }) {
   return (
-    <ClerkProvider>
-      <html lang="en">
-        <head>
+    <html lang="en">
+      <head>
           <link rel="preconnect" href="https://clerk.postergenius.ca" crossOrigin="" />
           {posthogKey ? <link rel="preconnect" href={posthogHost} crossOrigin="" /> : null}
           {/* Google Analytics 4 setup */}
@@ -112,20 +108,16 @@ export default function RootLayout({ children }) {
               unoptimized
             />
           </noscript>
-        </head>
-        <body
-          className={`${poppins.variable} font-sans text-blackhex antialiased`}
-        >
-          {/* Global toast notifications */}
-          <Toaster />
-          {/* Provide application context */}
-          <AppContextProvider>
-            <main className="mx-auto w-full max-w-content lg:px-0">
-              {children}
-            </main>
-          </AppContextProvider>
-        </body>
-      </html>
-    </ClerkProvider>
+      </head>
+      <body
+        className={`${poppins.variable} font-sans text-blackhex antialiased`}
+      >
+        <Providers>
+          <main className="mx-auto w-full max-w-content lg:px-0">
+            {children}
+          </main>
+        </Providers>
+      </body>
+    </html>
   );
 }

--- a/app/my-orders/MyOrdersClient.jsx
+++ b/app/my-orders/MyOrdersClient.jsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import axios from "axios";
 import toast from "react-hot-toast";
@@ -28,7 +27,8 @@ function resolveProductId(item) {
 export default function MyOrdersClient() {
   const pathname = usePathname();
   const router = useRouter();
-  const { getToken, user, setCartItems, fetchCart, currency } = useAppContext();
+  const { getToken, user, setCartItems, fetchCart, currency, ensureGuestId } =
+    useAppContext();
   const searchParams = useSearchParams();
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -65,11 +65,6 @@ export default function MyOrdersClient() {
         if (data?.success) {
           setCartItems({});
           await fetchCart({ createGuestIfMissing: false });
-
-          if (!user && data?.orderAccessUrl) {
-            router.replace(data.orderAccessUrl);
-            return;
-          }
 
           if (!data?.orderReady) {
             router.replace(pathname || "/my-orders");
@@ -119,14 +114,21 @@ export default function MyOrdersClient() {
       try {
         setLoading(true);
 
-        if (!user) {
-          if (!ignore) setOrders([]);
-          return;
+        const headers = {};
+        if (user) {
+          const token = await getToken();
+          headers.Authorization = `Bearer ${token}`;
+        } else {
+          const guestId = await ensureGuestId();
+          if (!guestId) {
+            if (!ignore) setOrders([]);
+            return;
+          }
+          headers["x-guest-id"] = guestId;
         }
 
-        const token = await getToken();
         const { data } = await axios.get("/api/order/list", {
-          headers: { Authorization: `Bearer ${token}` },
+          headers,
         });
 
         if (!ignore) {
@@ -154,9 +156,9 @@ export default function MyOrdersClient() {
     return () => {
       ignore = true;
     };
-  }, [confirming, getToken, user]);
+  }, [confirming, ensureGuestId, getToken, user]);
 
-  const downloadItem = async (item, order) => {
+  const downloadItem = async (item) => {
     const productId = resolveProductId(item);
     if (!productId) {
       toast.error("Download unavailable for this item");
@@ -166,8 +168,20 @@ export default function MyOrdersClient() {
     try {
       setDownloading(productId);
       const params = new URLSearchParams({ productId });
+      const headers = {};
 
-      const { data } = await axios.get(`/api/download-link?${params.toString()}`);
+      if (!user) {
+        const guestId = await ensureGuestId();
+        if (!guestId) {
+          toast.error("Guest session expired. Please sign in to recover this order.");
+          return;
+        }
+        headers["x-guest-id"] = guestId;
+      }
+
+      const { data } = await axios.get(`/api/download-link?${params.toString()}`, {
+        headers,
+      });
       if (data?.success && data?.url) {
         window.location.href = data.url;
       } else {
@@ -197,25 +211,6 @@ export default function MyOrdersClient() {
           {confirming || loading ? (
             <div className="py-12">
               <Loading />
-            </div>
-          ) : !user ? (
-            <div className="mt-8 rounded-2xl border border-stone-200 bg-white p-8 shadow-sm">
-              <h2 className="text-xl font-semibold text-blackhex">
-                Guest order access
-              </h2>
-              <p className="mt-3 max-w-2xl text-sm text-stone-600">
-                Guest orders are now accessed one order at a time using your email
-                address and order number. This keeps download and tracking access
-                scoped to the exact order you requested.
-              </p>
-              <div className="mt-6">
-                <Link
-                  href="/track-order"
-                  className="inline-flex h-11 items-center justify-center rounded-full bg-primary px-5 text-sm font-semibold text-white"
-                >
-                  Go to Track Order
-                </Link>
-              </div>
             </div>
           ) : orders.length === 0 ? (
             <div className="mt-8 rounded-2xl border border-dashed border-gray-300 bg-white p-8 text-sm text-gray-600">
@@ -309,7 +304,7 @@ export default function MyOrdersClient() {
                               {canDownload && (
                                 <button
                                   type="button"
-                                  onClick={() => downloadItem(item, order)}
+                                  onClick={() => downloadItem(item)}
                                   disabled={!productId || downloading === productId}
                                   className="rounded-full bg-primary px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
                                 >

--- a/app/providers.jsx
+++ b/app/providers.jsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { ClerkProvider } from "@clerk/nextjs";
+import { Toaster } from "react-hot-toast";
+import { AppContextProvider } from "@/context/AppContext";
+
+const clerkPublishableKey =
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ||
+  process.env.CLERK_PUBLISHABLE_KEY;
+
+export default function Providers({ children }) {
+  return (
+    <ClerkProvider publishableKey={clerkPublishableKey}>
+      <Toaster />
+      <AppContextProvider>{children}</AppContextProvider>
+    </ClerkProvider>
+  );
+}

--- a/components/GuestCheckoutSummary.jsx
+++ b/components/GuestCheckoutSummary.jsx
@@ -637,7 +637,7 @@ export default function GuestCheckoutSummary({
         </button>
         <p className="mt-3 text-center text-xs leading-5 text-stone-500">
           Secure payment handled by Stripe. Guest buyers can retrieve orders any
-          time from Track Order using email plus order number.
+          time from My Orders in this browser session.
         </p>
       </div>
     </div>

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -36,7 +36,6 @@ const Navbar = () => {
     { href: "/", label: "Home" },
     { href: "/shop", label: "Shop" },
     { href: "/videos", label: "How It Works" },
-    { href: "/track-order", label: "Track Order" },
     { href: "/about-us", label: "About Us" },
     { href: "/contact-us", label: "Contact" },
   ];

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -35,6 +35,7 @@ const Navbar = () => {
   const navLinks = [
     { href: "/", label: "Home" },
     { href: "/shop", label: "Shop" },
+    { href: "/my-orders", label: "My Orders" },
     { href: "/videos", label: "How It Works" },
     { href: "/about-us", label: "About Us" },
     { href: "/contact-us", label: "Contact" },

--- a/context/AppContext.jsx
+++ b/context/AppContext.jsx
@@ -614,6 +614,15 @@ export const AppContextProvider = (props) => {
           const token = await getToken();
           if (token) {
             await axios.post(
+              "/api/order/claim-guest",
+              { guestId: guestIdToMerge },
+              {
+                headers: {
+                  Authorization: `Bearer ${token}`,
+                },
+              }
+            );
+            await axios.post(
               "/api/cart/merge",
               { guestId: guestIdToMerge },
               {

--- a/middleware.ts
+++ b/middleware.ts
@@ -184,6 +184,13 @@ export default function middleware(request: NextRequest) {
     return redirectToPrimaryDomain(request);
   }
 
+  if (request.nextUrl.pathname.startsWith("/track-order")) {
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.pathname = "/my-orders";
+    redirectUrl.search = "";
+    return NextResponse.redirect(redirectUrl, 307);
+  }
+
   return clerkHandler(request);
 }
 

--- a/models/Order.js
+++ b/models/Order.js
@@ -78,8 +78,8 @@ const orderSchema = new mongoose.Schema(
     status: { type: String, required: true, default: "Order Placed" },
     date: { type: Number },
     stripeSessionId: { type: String, unique: true }, // Add this field
-    guestAccessToken: { type: String, index: true },
-    guestLookupTokenHash: { type: String, index: true },
+    guestAccessToken: { type: String },
+    guestLookupTokenHash: { type: String },
     guestLookupTokenExpiresAt: { type: Date },
     shippingCost: { type: Number },
     shippingCurrency: { type: String },


### PR DESCRIPTION
### Motivation
- Enable persistent guest order access across the site and allow guest orders to be claimed when a guest signs up or logs in.
- Replace legacy per-order guest lookup UX with a browser-session scoped "My Orders" experience and ensure APIs accept a guest identity header.

### Description
- Add a new endpoint `POST /api/order/claim-guest` to link guest orders to a user account by `guestId` or matching email addresses and unset `guestId` on matched orders.
- Extend `GET /api/download-link` and `GET /api/order/list` to accept a sanitized `x-guest-id` header and use it to identify guest orders when `userId` is absent.
- Update client flows in `MyOrdersClient.jsx` to attach `x-guest-id` for guest sessions via `ensureGuestId`, fetch orders for guest sessions, and include guest headers for download requests.
- On login, `AppContext` now calls the new `POST /api/order/claim-guest` (before cart merge) to associate guest orders with the newly authenticated user.
- Replace inline `ClerkProvider`, `Toaster`, and `AppContextProvider` usage in `app/layout.jsx` with a new `app/providers.jsx` wrapper component and update `RootLayout` to use `Providers`.
- Update UI copy and navigation: change references from `Track Order` to `My Orders`, remove the old standalone track-order navigation, and add a redirect from `/track-order` to `/my-orders` in `middleware.ts`.
- Tweak `Order` model to remove index flags on guest tokens and add/adjust several small logging and input sanitization touches.

### Testing
- Ran lint and the project's automated unit tests (`npm run lint` and `npm test`), which completed without failures.
- Performed a local smoke test of the order flow including guest checkout, login merge, and downloads which behaved as expected (automated test coverage unchanged).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e16abf5ce48326bf7075f9ef0aaf24)